### PR TITLE
Harden CI: least-privilege, concurrency, timeouts, pin actions + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
       - "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/maven-central-publish.yml
+++ b/.github/workflows/maven-central-publish.yml
@@ -9,11 +9,12 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -35,7 +36,7 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Monitor Snyk for vulnerabilities in code 📦
-        uses: snyk/actions/maven-3-jdk-21@master
+        uses: snyk/actions/maven-3-jdk-21@9cf6ca713d71123d2d229cc3d7f145b96ea3c518 # master
         env:
           JAVA_HOME: '' # Snyk action sets JAVA_HOME to a path that is not compatible with the setup-java action, so we need to reset it here
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -6,27 +6,33 @@
 name: Pull Request Check
 run-name: ${{ github.repository }} is evaluating pull request
 on: [pull_request]
+
+# Cancel superseded runs on the same PR to save CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: this job builds, runs CodeQL/PMD/Snyk and uploads SARIF.
+# It does not push commits, images or create attestations.
 permissions:
-    actions: read
-    security-events: write
-    contents: write
-    packages: write
-    attestations: write
-    id-token: write
+  actions: read
+  contents: read
+  security-events: write
 
 jobs:
   code-quality-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           languages: java
           config-file: ./.github/codeql/codeql-config.yml
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -35,22 +41,22 @@ jobs:
         run: mvn --batch-mode clean compile
         # Note: codeQL MUST be after the compile step
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           category: "/language:java"
       - name: Run PMD static analysis
-        uses: pmd/pmd-github-action@v2
+        uses: pmd/pmd-github-action@d9c1f3c5940cbf5923f1354e83fa858b4496ebaa # v2
         id: pmd
         with:
           rulesets: '.github/rulesets/java/pmd_omni_ruleset.xml'
 
       - name: Upload PMD SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           sarif_file: pmd-report.sarif
 
       - name: Run Snyk to check for vulnerabilities 🔍
-        uses: snyk/actions/maven-3-jdk-21@master
+        uses: snyk/actions/maven-3-jdk-21@9cf6ca713d71123d2d229cc3d7f145b96ea3c518 # master
         continue-on-error: false
         env:
           JAVA_HOME: '' # Snyk action sets JAVA_HOME to a path that is not compatible with the setup-java action, so we need to reset it here

--- a/.github/workflows/render-plantuml-diagrams.yml
+++ b/.github/workflows/render-plantuml-diagrams.yml
@@ -18,13 +18,14 @@ on:
 jobs:
   plantuml:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write  # Required to push changes back to the repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '21'
           distribution: 'temurin'


### PR DESCRIPTION
**Supply-chain hardening.** Least-privilege `permissions`, a `concurrency` group (cancel-in-progress), `timeout-minutes`, all actions pinned to commit SHAs, and a `github-actions` Dependabot entry.

---
**Notes**
- Snyk steps need maintainer-side `SNYK_TOKEN`/`SNYK_ORG` secrets; fork-PR CI runs only after a maintainer clicks *Approve and run*.
- DCO: commit signed off by Daniel Casota.