### PR TITLE
Fix/eidomni 858

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ replace the existing [verification material](https://www.w3.org/TR/did-core/#ver
 
 ```shell
 java -jar didtoolbox.jar create \
-    -u https://identifier-reg.trust-infra.swiyu-int.admin.ch/api/v1/did18fa7c77-9dd1-4e20-a147-fb1bec146085 > /tmp/my-did.jsonl
+    -u https://identifier-reg.trust-infra.swiyu-int.admin.ch/api/v1/did18fa7c77-9dd1-4e20-a147-fb1bec146085 > /tmp/did.jsonl
 
 # bear in mind, the command above will store the generated (auth/assert) keys in the .didtoolbox directory
 

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -8,8 +8,8 @@ This is the list of all third-party dependencies grouped by their license type. 
 ## Apache License, Version 2.0:
 
 * **Jackson-annotations** (com.fasterxml.jackson.core:jackson-annotations:2.21 - https://github.com/FasterXML/jackson)
-* **Jackson-core** (com.fasterxml.jackson.core:jackson-core:2.21.2 - https://github.com/FasterXML/jackson-core)
-* **jackson-databind** (com.fasterxml.jackson.core:jackson-databind:2.21.2 - https://github.com/FasterXML/jackson)
+* **Jackson-core** (com.fasterxml.jackson.core:jackson-core:2.21.3 - https://github.com/FasterXML/jackson-core)
+* **jackson-databind** (com.fasterxml.jackson.core:jackson-databind:2.21.3 - https://github.com/FasterXML/jackson)
 * **FindBugs-jsr305** (com.google.code.findbugs:jsr305:3.0.2 - http://findbugs.sourceforge.net/)
 * **Gson** (com.google.code.gson:gson:2.14.0 - https://github.com/google/gson)
 * **Tink Cryptography API** (com.google.crypto.tink:tink:1.21.0 - http://github.com/tink-crypto/tink-java)
@@ -36,12 +36,12 @@ This is the list of all third-party dependencies grouped by their license type. 
 ## Eclipse Public License v2.0:
 
 * **junit-pioneer** (org.junit-pioneer:junit-pioneer:2.3.0 - https://junit-pioneer.org/)
-* **JUnit Jupiter (Aggregator)** (org.junit.jupiter:junit-jupiter:6.0.3 - https://junit.org/)
-* **JUnit Jupiter API** (org.junit.jupiter:junit-jupiter-api:6.0.3 - https://junit.org/)
-* **JUnit Jupiter Engine** (org.junit.jupiter:junit-jupiter-engine:6.0.3 - https://junit.org/)
-* **JUnit Jupiter Params** (org.junit.jupiter:junit-jupiter-params:6.0.3 - https://junit.org/)
-* **JUnit Platform Commons** (org.junit.platform:junit-platform-commons:6.0.3 - https://junit.org/)
-* **JUnit Platform Engine API** (org.junit.platform:junit-platform-engine:6.0.3 - https://junit.org/)
+* **JUnit Jupiter (Aggregator)** (org.junit.jupiter:junit-jupiter:6.1.0 - https://junit.org/)
+* **JUnit Jupiter API** (org.junit.jupiter:junit-jupiter-api:6.1.0 - https://junit.org/)
+* **JUnit Jupiter Engine** (org.junit.jupiter:junit-jupiter-engine:6.1.0 - https://junit.org/)
+* **JUnit Jupiter Params** (org.junit.jupiter:junit-jupiter-params:6.1.0 - https://junit.org/)
+* **JUnit Platform Commons** (org.junit.platform:junit-platform-commons:6.1.0 - https://junit.org/)
+* **JUnit Platform Engine API** (org.junit.platform:junit-platform-engine:6.1.0 - https://junit.org/)
 
 ## LGPL-2.1-or-later:
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <!--project.dependencies.directory>lib/</project.dependencies.directory-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <didresolver.version>2.8.0</didresolver.version>
+        <didresolver.version>2.8.1</didresolver.version>
         <jna.version>5.18.1</jna.version>
         <gson.version>2.14.0</gson.version>
         <lombok.version>1.18.46</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <!--project.dependencies.directory>lib/</project.dependencies.directory-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <didresolver.version>2.7.0</didresolver.version>
+        <didresolver.version>2.8.0</didresolver.version>
         <jna.version>5.18.1</jna.version>
         <gson.version>2.14.0</gson.version>
         <lombok.version>1.18.46</lombok.version>

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/AbstractDidLogEntryBuilder.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/AbstractDidLogEntryBuilder.java
@@ -9,6 +9,7 @@ import com.google.gson.*;
 
 import java.net.URL;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public abstract class AbstractDidLogEntryBuilder {
     protected static final String SCID_PLACEHOLDER = "{SCID}";
@@ -180,6 +181,14 @@ public abstract class AbstractDidLogEntryBuilder {
         - The value of 'nextKeyHashes' MAY be set to an empty array ([]) to deactivate pre-rotation.
           For additional details about turning off pre-rotation, see the Pre-Rotation Key Hash Generation and Verification section of this specification.
          */
+        if (updateKeysParameter != null && nextKeyHashesDidMethodParameters != null) {
+            var updateKeyHashes = updateKeysParameter.stream().map(key -> NextKeyHashesDidMethodParameter.of(key.getUpdateKey()).getNextKeyHash()).collect(Collectors.toSet());
+            var nextKeyHashes = nextKeyHashesDidMethodParameters.stream().map(NextKeyHashesDidMethodParameter::getNextKeyHash).collect(Collectors.toSet());
+            updateKeyHashes.retainAll(nextKeyHashes);
+            if (!updateKeyHashes.isEmpty()) {
+                throw new DidLogCreatorStrategyException("Key is not allowed to be in both update keys and next key hashes.");
+            }
+        }
         var nextKeyHashesJsonArray = new JsonArray();
         // Once the nextKeys/nextKeyHashes parameters has been set to a non-empty array, Key Pre-Rotation is active.
         try {
@@ -224,7 +233,7 @@ public abstract class AbstractDidLogEntryBuilder {
         if (!path.isEmpty()) {
             did = "%s%s".formatted(did,
                     path.replace("/did.jsonl", "") // cleanup
-                            .replace("/", ":")); // w.r.t. https://identity.foundation/didwebvh/v1.0/#the-did-to-https-transformation);
+                            .replace("/", ":")); // w.r.t. https://identity.foundation/didwebvh/v1.0/#the-did-to-https-transformation
         }
 
         return did;
@@ -252,7 +261,6 @@ public abstract class AbstractDidLogEntryBuilder {
         // CAUTION The "controller" property must not be present w.r.t.:
         // - https://jira.bit.admin.ch/browse/EIDSYS-352
         // - https://confluence.bit.admin.ch/display/EIDTEAM/DID+Doc+Conformity+Check
-        //didDoc.addProperty("controller", did);
 
         var profileVersion = this.getProfileVersion();
         if (profileVersion != null) {

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/AbstractDidLogEntryBuilder.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/AbstractDidLogEntryBuilder.java
@@ -99,6 +99,7 @@ public abstract class AbstractDidLogEntryBuilder {
 
     /**
      * Returns the value for the `profile_version` attribute in the did document.
+     *
      * @return profile version
      */
     protected abstract ProfileVersion getProfileVersion();

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/JCommanderRunner.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/JCommanderRunner.java
@@ -303,90 +303,18 @@ final class JCommanderRunner {
 
         VcDataIntegrityCryptographicSuite cryptoSuite = null; // no default, must be supplied
 
-        if (signingKeyPemFile != null && verifyingKeyPemFiles != null) {
-
-            String matchingUpdateKey = null;
-
-            if (didLogMeta.isKeyPreRotationActivated()) {
-
-                for (var pemFile : verifyingKeyPemFiles) {
-                    try {
-                        var multikey = PemUtils.readEd25519PublicKeyPemFileToMultibase(pemFile.toPath());
-                        // Only pre-rotation keys are relevant here
-                        if (didLogMeta.isPreRotatedUpdateKey(multikey)) {
-                            // the signing key is supplied externally, but verifying key should be already among updateKeys
-                            cryptoSuite = new EdDsaJcs2022VcDataIntegrityCryptographicSuite(signingKeyPemFile.toPath());
-                            if (multikey.equals(cryptoSuite.getVerificationKeyMultibase())) {
-                                // At this point, the matching verifying key is detected, so we are free to break from the loop
-                                matchingUpdateKey = multikey;
-                                break;
-                            }
-                        }
-                    } catch (VcDataIntegrityCryptographicSuiteException |
-                             DidSidekicksException ignoreMalformedPemFiles) {
-                    }
-                }
-
-            } else {
-
-                for (var pemFile : verifyingKeyPemFiles) {
-                    try {
-                        var publicKeyEd25519Multibase = PemUtils.readEd25519PublicKeyPemFileToMultibase(pemFile.toPath());
-                        // the signing key is supplied externally, but verifying key should be already among updateKeys
-                        cryptoSuite = new EdDsaJcs2022VcDataIntegrityCryptographicSuite(signingKeyPemFile.toPath());
-                        if (publicKeyEd25519Multibase.equals(cryptoSuite.getVerificationKeyMultibase())) {
-                            // At this point, the matching verifying key is detected, so we are free to break from the loop
-                            matchingUpdateKey = publicKeyEd25519Multibase;
-                            break;
-                        }
-                    } catch (VcDataIntegrityCryptographicSuiteException |
-                             DidSidekicksException ignoreMalformedPemFiles) {
-                    }
-                }
-
-                if (matchingUpdateKey == null) {
-                    return printCommandError(jc, parsedCommandName, "No valid matching verifying (public) ed25519 key supplied");
-                }
-
-                if (didLogMeta.getParams().getUpdateKeys() == null || didLogMeta.getParams().getUpdateKeys().isEmpty()) {
-                    return printCommandError(jc, parsedCommandName, "Provided Did can no longer be updated");
-                }
-                for (var publicKeyEd25519Multibase : didLogMeta.getParams().getUpdateKeys()) {
-                    try {
-                        // the signing key is supplied externally, but verifying key should be already among updateKeys
-                        cryptoSuite = new EdDsaJcs2022VcDataIntegrityCryptographicSuite(signingKeyPemFile.toPath());
-                        if (publicKeyEd25519Multibase.equals(cryptoSuite.getVerificationKeyMultibase())) {
-                            // At this point, the matching verifying key is detected, so we are free to break from the loop
-                            matchingUpdateKey = publicKeyEd25519Multibase;
-                            break;
-                        }
-                    } catch (VcDataIntegrityCryptographicSuiteException ignoreMalformedPemFiles) {
-                    }
-                }
-            }
-
-            if (matchingUpdateKey == null) {
-                return printCommandError(jc, parsedCommandName, "No matching signing (private) ed25519 key supplied");
-            }
-
+        if (signingKeyPemFile != null) {
+            cryptoSuite = new EdDsaJcs2022VcDataIntegrityCryptographicSuite(signingKeyPemFile.toPath());
         } else if (jksFile != null && jksAlias != null) {
             // CAUTION Different store and key passwords not supported for PKCS12 KeyStores
             cryptoSuite = new EdDsaJcs2022VcDataIntegrityCryptographicSuite(Files.newInputStream(jksFile.toPath()), jksPassword, jksAlias, jksPassword); // supplied external key pair
-
-            if (didLogMeta.isKeyPreRotationActivated() && !didLogMeta.isPreRotatedUpdateKey(cryptoSuite.getVerificationKeyMultibase())) {
-                return printCommandError(jc, parsedCommandName, "Illegal signing (private) ed25519 key supplied");
-            }
-
         } else if (primus != null && primusKeyAlias != null) { // && primusKeyPassword != null) {
-
             cryptoSuite = new PrimusEd25519VerificationMethodKeyProviderImpl(primus, primusKeyAlias, primusKeyPassword); // supplied external key pair
-
-            if (didLogMeta.isKeyPreRotationActivated() && !didLogMeta.isPreRotatedUpdateKey(cryptoSuite.getVerificationKeyMultibase())) {
-                return printCommandError(jc, parsedCommandName, "Illegal signing (private) ed25519 key supplied");
-            }
-
         } else {
             return printCommandError(jc, parsedCommandName, "Incomplete source of the (signing/verifying) ed25519 keys supplied. Use one of the relevant options to supply keys");
+        }
+        if (didLogMeta.isKeyPreRotationActivated() && !didLogMeta.isPreRotatedUpdateKey(cryptoSuite.getVerificationKeyMultibase())) {
+            return printCommandError(jc, parsedCommandName, "Illegal signing (private) ed25519 key supplied");
         }
 
         // CAUTION At this point, the methodVersion var of type DidMethodEnum MUST be non-null already

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/JCommanderRunner.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/JCommanderRunner.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
  */
 @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.DoNotTerminateVM"})
 final class JCommanderRunner {
+    private static final String TOOLBOX_DIR = ".didtoolbox";
 
     private final JCommander jc;
     private final String parsedCommandName;
@@ -87,8 +88,6 @@ final class JCommanderRunner {
             } catch (DirectoryNotEmptyException | FileAlreadyExistsException | AccessDeniedException ex) {
                 // the directory (if exists) must be empty with write access granted
                 throw new IllegalArgumentException(ex);
-                //} catch (AccessDeniedException ex) {
-                //    throw new AccessDeniedException("Access denied to " + outputDir.getPath() + " due to: " + ex.getMessage());
             } catch (Throwable thr) {
                 throw new DidLogCreatorStrategyException("Failed to create private directory " + pathname + " due to: " + thr.getMessage(), thr);
             }
@@ -121,7 +120,7 @@ final class JCommanderRunner {
                 assertionMethods.add(VerificationMethod.of(param.key, param.jwk));
             }
         } else {
-            createPrivateKeyDirectoryIfDoesNotExist(".didtoolbox");
+            createPrivateKeyDirectoryIfDoesNotExist(TOOLBOX_DIR);
             assertionMethods.add(VerificationMethod.of("assert-key-01",
                     JwkUtils.generatePublicEC256("assert-key-01", Path.of(".didtoolbox/assert-key-01").toFile(), forceOverwrite)));
         }
@@ -133,7 +132,7 @@ final class JCommanderRunner {
                 authentications.add(VerificationMethod.of(param.key, param.jwk));
             }
         } else {
-            createPrivateKeyDirectoryIfDoesNotExist(".didtoolbox");
+            createPrivateKeyDirectoryIfDoesNotExist(TOOLBOX_DIR);
             authentications.add(VerificationMethod.of("auth-key-01",
                     JwkUtils.generatePublicEC256("auth-key-01", Path.of(".didtoolbox/auth-key-01").toFile(), forceOverwrite)));
         }
@@ -190,7 +189,7 @@ final class JCommanderRunner {
             var dalekSigner = new EdDsaJcs2022VcDataIntegrityCryptographicSuite();
             cryptoSuite = dalekSigner;
 
-            var outputDir = new File(".didtoolbox");
+            var outputDir = new File(TOOLBOX_DIR);
             if (!outputDir.exists() || forceOverwrite) {
 
                 try {
@@ -357,10 +356,9 @@ final class JCommanderRunner {
         var primusKeyAlias = command.primusKeyAlias;
         var primusKeyPassword = command.primusKeyPassword;
 
-        VcDataIntegrityCryptographicSuite cryptoSuite = null; // no default, must be supplied
+        VcDataIntegrityCryptographicSuite cryptoSuite = null;
 
         if (signingKeyPemFile != null) {
-
             String matchingUpdateKey = null;
             // CAUTION In case the supplied DID log have already been deactivated (i.e. "parameters":{"deactivated":true,"updateKeys":[]}),
             //         the updateKeys collection would be null
@@ -382,15 +380,11 @@ final class JCommanderRunner {
                     return printCommandError(jc, parsedCommandName, "No valid matching signing key supplied");
                 }
             }
-
         } else if (jksFile != null && jksPassword != null && jksAlias != null) {
             // CAUTION Different store and key passwords not supported for PKCS12 KeyStores
             cryptoSuite = new EdDsaJcs2022VcDataIntegrityCryptographicSuite(Files.newInputStream(jksFile.toPath()), jksPassword, jksAlias, jksPassword); // supplied external key pair
-
-        } else if (primus != null && primusKeyAlias != null) { // && primusKeyPassword != null) {
-
+        } else if (primus != null && primusKeyAlias != null) {
             cryptoSuite = new PrimusEd25519VerificationMethodKeyProviderImpl(primus, primusKeyAlias, primusKeyPassword); // supplied external key pair
-
         } else {
             return printCommandError(jc, parsedCommandName, "No valid source of signing/verifying ed25519 keys supplied. Use one of the relevant options to supply keys");
         }

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/Main.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/Main.java
@@ -27,6 +27,7 @@ public class Main {
 
     /**
      * Entrypoint of the cli, prints output to the stdout.
+     *
      * @param args Arguments to CLI is called with
      */
     public static void main(String... args) {
@@ -39,6 +40,7 @@ public class Main {
 
     /**
      * Instantiates the main, allowing for custom console/output
+     *
      * @param console Console to print the output to
      */
     public Main(Console console) {
@@ -47,6 +49,7 @@ public class Main {
 
     /**
      * Runs the CLI
+     *
      * @param args cli arguments to be parsed and then executed
      * @return the exit code
      */

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/TdwDeactivator.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/TdwDeactivator.java
@@ -7,8 +7,6 @@ import ch.admin.bj.swiyu.didtoolbox.model.NamedDidMethodParameters;
 import ch.admin.bj.swiyu.didtoolbox.model.ProfileVersion;
 import ch.admin.bj.swiyu.didtoolbox.vc_data_integrity.VcDataIntegrityCryptographicSuite;
 import ch.admin.eid.did_sidekicks.DidSidekicksException;
-import ch.admin.eid.didresolver.Did;
-import ch.admin.eid.didresolver.DidResolveException;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import lombok.AccessLevel;
@@ -61,7 +59,7 @@ public class TdwDeactivator extends AbstractDidLogEntryBuilder implements DidLog
      * @deprecated Use {@link #cryptographicSuite} instead. Since 1.8.0
      */
     @Getter(AccessLevel.PRIVATE)
-    @Deprecated
+    @Deprecated(since = "1.8.0")
     private VcDataIntegrityCryptographicSuite verificationMethodKeyProvider;
 
     private VcDataIntegrityCryptographicSuite getCryptoSuite() {
@@ -87,7 +85,7 @@ public class TdwDeactivator extends AbstractDidLogEntryBuilder implements DidLog
      *
      * @deprecated Use {@link #deactivateDidLog(String)} instead
      */
-    @Deprecated
+    @Deprecated(since = "1.6.0")
     public String deactivate(String didLog) throws TdwDeactivatorException {
         try {
             return deactivateDidLog(didLog, ZonedDateTime.now());
@@ -115,7 +113,7 @@ public class TdwDeactivator extends AbstractDidLogEntryBuilder implements DidLog
      *
      * @deprecated Use {@link #deactivateDidLog(File)} instead
      */
-    @Deprecated
+    @Deprecated(since = "1.6.0")
     String deactivate(File didLogFile) throws TdwDeactivatorException, IOException {
         try {
             return deactivateDidLog(Files.readString(didLogFile.toPath()), ZonedDateTime.now());
@@ -144,7 +142,7 @@ public class TdwDeactivator extends AbstractDidLogEntryBuilder implements DidLog
      *
      * @deprecated Use {@link #deactivateDidLog(String, ZonedDateTime)} instead
      */
-    @Deprecated
+    @Deprecated(since = "1.6.0")
     public String deactivate(String didLog, ZonedDateTime zdt) throws TdwDeactivatorException {
         try {
             return deactivateDidLog(didLog, zdt);
@@ -202,7 +200,6 @@ public class TdwDeactivator extends AbstractDidLogEntryBuilder implements DidLog
         // CAUTION "controller" property is omitted w.r.t.:
         // - https://jira.bit.admin.ch/browse/EIDSYS-352
         // - https://confluence.bit.admin.ch/display/EIDTEAM/DID+Doc+Conformity+Check
-        //didDoc.addProperty("controller", didTDW);
 
         // The DID log entry is an input JSON array that when completed contains the following items:
         // [ versionId, versionTime, parameters, DIDDoc State, Data Integrity Proof ].

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/TdwDeactivator.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/TdwDeactivator.java
@@ -275,18 +275,7 @@ public class TdwDeactivator extends AbstractDidLogEntryBuilder implements DidLog
         proofs.add(proof);
         didLogEntryWithProof.add(proofs);
 
-        try (var did = new Did(didLogMeta.getDidDoc().getId())) {
-            // NOTE Enforcing DID log conformity by calling:
-            //      ch.admin.eid.didtoolbox.DidLogEntryValidator.Companion
-            //          .from(DidLogEntryJsonSchema.V03_EID_CONFORM)
-            //          .validate(didLogEntryWithProof.toString());
-            //      would not be necessary here, as it is already part of the `resolve` method.
-            // CAUTION Trimming the existing DID log prevents ending up having multiple line separators in between (after appending the new entry)
-            did.resolveAll(didLog.trim() + System.lineSeparator() + didLogEntryWithProof); // sanity check
-        } catch (DidResolveException e) {
-            throw new InvalidDidLogException("Deactivating the DID log resulted in unresolvable/unverifiable DID log", e);
-        }
-
+        // skip final resolve check, as resolver returns an error when resolving a deactivated did
         return didLogEntryWithProof.toString();
     }
 }

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/jcommander/CreateProofOfPossessionCommand.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/jcommander/CreateProofOfPossessionCommand.java
@@ -16,7 +16,7 @@ public class CreateProofOfPossessionCommand extends AbstractCommandBase {
     final public static String COMMAND_NAME = "create-pop";
 
     @Override
-    String getCommandName(){
+    String getCommandName() {
         return COMMAND_NAME;
     }
 

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/jcommander/DeactivateDidLogCommand.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/jcommander/DeactivateDidLogCommand.java
@@ -23,7 +23,7 @@ import java.io.File;
 public class DeactivateDidLogCommand extends AbstractDidLogCommandBase {
 
     @Override
-    String getCommandName(){
+    String getCommandName() {
         return COMMAND_NAME;
     }
 

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/model/DidLogMeta.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/model/DidLogMeta.java
@@ -27,15 +27,15 @@ import java.util.Set;
  */
 public class DidLogMeta {
     @Getter
-    final private String lastVersionId;
+    private final String lastVersionId;
     @Getter
     final int lastVersionNumber;
     @Getter
-    final private String dateTime;
+    private final String dateTime;
     @Getter
     private NamedDidMethodParameters params;
     @Getter
-    final private DidDoc didDoc;
+    private final DidDoc didDoc;
 
     DidLogMeta(String lastVersionId, int lastVersionNumber, String dateTime, Map<String, DidMethodParameter> paramsMap, DidDoc didDoc) {
         this.lastVersionId = lastVersionId;

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/model/DidLogMeta.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/model/DidLogMeta.java
@@ -26,7 +26,6 @@ import java.util.Set;
  * </ul>
  */
 public class DidLogMeta {
-
     @Getter
     final private String lastVersionId;
     @Getter
@@ -83,7 +82,6 @@ public class DidLogMeta {
      * @return {@code true} if and only if the supplied {@code multikey} is legal w.r.t. key pre-rotation. Otherwise, {@code false}.
      */
     public boolean isPreRotatedUpdateKey(String multikey) {
-
         if (this.isKeyPreRotationActivated() && multikey != null) {
             return this.getParams().getNextKeyHashes().contains(
                     NextKeyHashesDidMethodParameter.of(multikey).getNextKeyHash());
@@ -102,7 +100,6 @@ public class DidLogMeta {
      *                                               at least one of the supplied {@code pemFiles} contains no valid Ed25519 public key
      */
     public boolean arePreRotatedUpdateKeys(Set<UpdateKeysDidMethodParameter> params) throws UpdateKeysDidMethodParameterException {
-
         if (params != null && !params.isEmpty()) {
             for (var param : params) {
                 if (!this.isPreRotatedUpdateKey(param.getUpdateKey())) {

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/model/ProfileVersion.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/model/ProfileVersion.java
@@ -7,6 +7,7 @@ public enum ProfileVersion {
     SWISS_PROFILE_ANCHOR_1_0_0("swiss-profile-anchor:1.0.0");
 
     private final String value;
+
     ProfileVersion(String value) {
         this.value = value;
     }

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryCreator.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryCreator.java
@@ -257,7 +257,7 @@ public class WebVerifiableHistoryCreator extends AbstractDidLogEntryBuilder impl
         didDoc.getAuthentication().stream()
                 .map(vm -> did + "#" + Arrays.stream(vm.getId().split("#")).skip(1).collect(Collectors.joining()))
                 .forEach(authentication::add);
-        newDidDoc.add( DID_DOC_PROPERTY_AUTHENTICATION, authentication);
+        newDidDoc.add(DID_DOC_PROPERTY_AUTHENTICATION, authentication);
 
         var assertionMethod = new JsonArray();
         didDoc.getAssertionMethod().stream()

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryDeactivator.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryDeactivator.java
@@ -239,17 +239,14 @@ public class WebVerifiableHistoryDeactivator extends AbstractDidLogEntryBuilder 
            "Makes each DID version’s Data Integrity proof apply across the JSON DID log entry object, as is typical with Data Integrity proofs.
            Previously, the Data Integrity proof was generated across the current DIDDoc version, with the versionId as the challenge."
          */
-        try (var did = new Did(super.didLogMeta.getDidDoc().getId())) {
+        try {
             var didLogEntry = this.getCryptoSuite().addProof(
                     didLogEntryWithoutProof.toString(), null, JCSHasher.PROOF_PURPOSE_ASSERTION_METHOD, zdt);
 
-            did.resolveAll(didLog.trim() + System.lineSeparator() + didLogEntry); // sanity check
-
+            // skip final resolve check, as resolver returns an error when resolving a deactivated did
             return didLogEntry;
         } catch (VcDataIntegrityCryptographicSuiteException exc) {
             throw new DidLogDeactivatorStrategyException(exc);
-        } catch (DidResolveException exc) {
-            throw new InvalidDidLogException("Deactivating the DID log resulted in unresolvable/unverifiable DID log", exc);
         }
     }
 }

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryDeactivator.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryDeactivator.java
@@ -8,8 +8,6 @@ import ch.admin.bj.swiyu.didtoolbox.model.NamedDidMethodParameters;
 import ch.admin.bj.swiyu.didtoolbox.model.ProfileVersion;
 import ch.admin.bj.swiyu.didtoolbox.vc_data_integrity.VcDataIntegrityCryptographicSuite;
 import ch.admin.bj.swiyu.didtoolbox.vc_data_integrity.VcDataIntegrityCryptographicSuiteException;
-import ch.admin.eid.didresolver.Did;
-import ch.admin.eid.didresolver.DidResolveException;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import lombok.AccessLevel;
@@ -62,7 +60,7 @@ public class WebVerifiableHistoryDeactivator extends AbstractDidLogEntryBuilder 
      * @deprecated Use {@link #cryptographicSuite} instead. Since 1.8.0
      */
     @Getter(AccessLevel.PRIVATE)
-    @Deprecated
+    @Deprecated(since = "1.8.0")
     private VcDataIntegrityCryptographicSuite verificationMethodKeyProvider;
 
     @Override
@@ -167,7 +165,6 @@ public class WebVerifiableHistoryDeactivator extends AbstractDidLogEntryBuilder 
         // CAUTION "controller" property is omitted w.r.t.:
         // - https://jira.bit.admin.ch/browse/EIDSYS-352
         // - https://confluence.bit.admin.ch/display/EIDTEAM/DID+Doc+Conformity+Check
-        //didDoc.addProperty("controller", didTDW);
 
         /* https://identity.foundation/didwebvh/v1.0/#the-did-log-file:
         The DID log file contains a list of entries, one for each version of the DID
@@ -240,11 +237,9 @@ public class WebVerifiableHistoryDeactivator extends AbstractDidLogEntryBuilder 
            Previously, the Data Integrity proof was generated across the current DIDDoc version, with the versionId as the challenge."
          */
         try {
-            var didLogEntry = this.getCryptoSuite().addProof(
-                    didLogEntryWithoutProof.toString(), null, JCSHasher.PROOF_PURPOSE_ASSERTION_METHOD, zdt);
-
             // skip final resolve check, as resolver returns an error when resolving a deactivated did
-            return didLogEntry;
+            return this.getCryptoSuite().addProof(didLogEntryWithoutProof.toString(), null, JCSHasher.PROOF_PURPOSE_ASSERTION_METHOD, zdt);
+
         } catch (VcDataIntegrityCryptographicSuiteException exc) {
             throw new DidLogDeactivatorStrategyException(exc);
         }

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryUpdater.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryUpdater.java
@@ -394,13 +394,13 @@ public class WebVerifiableHistoryUpdater extends AbstractDidLogEntryBuilder impl
         // While Key Pre-Rotation is active, all multikey formatted public keys added in a new 'updateKeys' list
         // MUST have their hashes listed in the 'nextKeyHashes' list from the previous log entry.
         if (super.didLogMeta.isKeyPreRotationActivated()) {
-            var updateKeys = this.allUpdateKeysDidMethodParameter();
-            if (updateKeys.isEmpty()) {
+            var newUpdateKeys = this.allUpdateKeysDidMethodParameter();
+            if (newUpdateKeys.isEmpty()) {
                 throw new DidLogUpdaterStrategyException("Must provide update keys during key pre-rotation");
             }
 
             try {
-                if (!super.didLogMeta.arePreRotatedUpdateKeys(updateKeys)) {
+                if (!super.didLogMeta.arePreRotatedUpdateKeys(newUpdateKeys)) {
                     throw new DidLogUpdaterStrategyException("Illegal update key detected, not all verification keys are allowed to rotate to.");
                 }
             } catch (UpdateKeysDidMethodParameterException e) {
@@ -414,7 +414,7 @@ public class WebVerifiableHistoryUpdater extends AbstractDidLogEntryBuilder impl
         // The versionTime for each log entry MUST be greater than the previous entry’s time.
         // The versionTime of the last entry MUST be earlier than the current time.
         var lastEntryDateTime = ZonedDateTime.parse(super.didLogMeta.getDateTime());
-        if (zdt.isBefore(lastEntryDateTime) || zdt.isEqual(lastEntryDateTime)) {
+        if (!lastEntryDateTime.isBefore(zdt)) {
             throw new DidLogUpdaterStrategyException("The versionTime of the last entry MUST be earlier than the current time");
         }
 
@@ -439,28 +439,22 @@ public class WebVerifiableHistoryUpdater extends AbstractDidLogEntryBuilder impl
         var verificationMethod = new JsonArray();
 
         if (!this.allAuthentications().isEmpty()) {
-
             JsonArray authentication = new JsonArray();
             for (var vm : this.allAuthentications()) {
-
                 authentication.add(this.didLogMeta.getDidDoc().getId() + "#" + vm.getIdFragment());
                 verificationMethod.add(buildVerificationMethodWithPublicKeyJwk(
                         this.didLogMeta.getDidDoc().getId(), vm.getIdFragment(), vm.getVerificationMaterial().getPublicKeyJwk()));
             }
-
             didDoc.add(DID_DOC_PROPERTY_AUTHENTICATION, authentication);
         }
 
         if (!this.allAssertionMethods().isEmpty()) {
-
             var assertionMethod = new JsonArray();
             for (var vm : this.allAssertionMethods()) {
-
                 assertionMethod.add(this.didLogMeta.getDidDoc().getId() + "#" + vm.getIdFragment());
                 verificationMethod.add(buildVerificationMethodWithPublicKeyJwk(
                         this.didLogMeta.getDidDoc().getId(), vm.getIdFragment(), vm.getVerificationMaterial().getPublicKeyJwk()));
             }
-
             didDoc.add(DID_DOC_PROPERTY_ASSERTION_METHOD, assertionMethod);
         }
 

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryUpdater.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryUpdater.java
@@ -412,16 +412,10 @@ public class WebVerifiableHistoryUpdater extends AbstractDidLogEntryBuilder impl
                 throw new DidLogUpdaterStrategyException("Illegal updateKey detected");
             }
 
-        } else if (!this.allUpdateKeysDidMethodParameter().isEmpty()) {
-
-            for (var param : this.allUpdateKeysDidMethodParameter()) {
-                if (!this.getCryptoSuite().getVerificationKeyMultibase().equals(param.getUpdateKey())) {
-                    throw new DidLogUpdaterStrategyException("No matching verifying (public) ed25519 key supplied");
-                }
-            }
         }
 
         // The second item in the input JSON array MUST be a valid ISO8601 date/time string,
+
         // and that the represented time MUST be before or equal to the current time.
         //
         // The versionTime for each log entry MUST be greater than the previous entry’s time.
@@ -620,18 +614,15 @@ public class WebVerifiableHistoryUpdater extends AbstractDidLogEntryBuilder impl
         var updateKeysJsonArray = new JsonArray();
         var nextKeyHashesJsonArray = new JsonArray();
 
-        if (super.didLogMeta.isKeyPreRotationActivated()) {
-            var updateKeys = loadUpdateKeys();
-            updateKeys.add(this.cryptographicSuite.getVerificationKeyMultibase());
-            updateKeys.forEach(updateKeysJsonArray::add);
+        var nextUpdateKeys = loadUpdateKeys();
+        if (!nextUpdateKeys.isEmpty()) {
+            nextUpdateKeys.forEach(updateKeysJsonArray::add);
             didMethodParameters.add(NamedDidMethodParameters.UPDATE_KEYS, updateKeysJsonArray);
-
-            didMethodParameters.add(NamedDidMethodParameters.NEXT_KEY_HASHES, nextKeyHashesJsonArray); // to deactivate key rotation
         }
 
-        if (this.shouldActivateKeyPreRotation()) {
+        if (this.shouldActivateKeyPreRotation() || didLogMeta.isKeyPreRotationActivated()) {
             loadNextUpdateKeys().forEach(nextKeyHashesJsonArray::add);
-            didMethodParameters.add(NamedDidMethodParameters.NEXT_KEY_HASHES, nextKeyHashesJsonArray);
+            didMethodParameters.add(NamedDidMethodParameters.NEXT_KEY_HASHES, nextKeyHashesJsonArray); // to deactivate key rotation
         }
 
         return didMethodParameters;

--- a/src/main/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryUpdater.java
+++ b/src/main/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryUpdater.java
@@ -268,7 +268,6 @@ public class WebVerifiableHistoryUpdater extends AbstractDidLogEntryBuilder impl
      * @since 1.9.0
      */
     private Set<UpdateKeysDidMethodParameter> allUpdateKeysDidMethodParameter() throws DidLogUpdaterStrategyException {
-
         var set = new HashSet<UpdateKeysDidMethodParameter>();
         if (this.updateKeys != null) { // collect all from deprecated class member
             for (var key : this.updateKeys) {
@@ -297,7 +296,6 @@ public class WebVerifiableHistoryUpdater extends AbstractDidLogEntryBuilder impl
      * @since 1.9.0
      */
     private Set<NextKeyHashesDidMethodParameter> allNextKeyHashesDidMethodParameter() throws DidLogUpdaterStrategyException {
-
         var set = new HashSet<NextKeyHashesDidMethodParameter>();
         if (this.nextKeys != null) { // collect all from deprecated class member
             for (var key : this.nextKeys) {
@@ -380,42 +378,37 @@ public class WebVerifiableHistoryUpdater extends AbstractDidLogEntryBuilder impl
     @SuppressWarnings({"PMD.NcssCount", "PMD.CognitiveComplexity", "PMD.CyclomaticComplexity"})
     @Override
     public String updateDidLog(String resolvableDidLog, ZonedDateTime zdt) throws DidLogUpdaterStrategyException {
-
         try {
             super.peek(resolvableDidLog);
         } catch (DidLogMetaPeekerException e) {
             throw new DidLogUpdaterStrategyException(e);
         }
 
-        // CAUTION Only activated DIDs can be updated
-        if (super.didLogMeta.getParams().getDeactivated() != null && super.didLogMeta.getParams().getDeactivated()) {
-            throw new DidLogUpdaterStrategyException("DID already deactivated");
-        }
-
         if (getCryptoSuite() == null) {
             throw new IncompleteDidLogEntryBuilderException("No cryptographic suite supplied");
-        } else if (!super.isVerificationMethodKeyProviderLegal(this.getCryptoSuite())) {
+        }
+        if (!super.isVerificationMethodKeyProviderLegal(this.getCryptoSuite())) {
             throw new DidLogUpdaterStrategyException("Update key mismatch");
         }
 
         // While Key Pre-Rotation is active, all multikey formatted public keys added in a new 'updateKeys' list
         // MUST have their hashes listed in the 'nextKeyHashes' list from the previous log entry.
         if (super.didLogMeta.isKeyPreRotationActivated()) {
-            boolean arePreRotatedUpdateKeys;
+            var updateKeys = this.allUpdateKeysDidMethodParameter();
+            if (updateKeys.isEmpty()) {
+                throw new DidLogUpdaterStrategyException("Must provide update keys during key pre-rotation");
+            }
+
             try {
-                arePreRotatedUpdateKeys = super.didLogMeta.arePreRotatedUpdateKeys(this.allUpdateKeysDidMethodParameter());
+                if (!super.didLogMeta.arePreRotatedUpdateKeys(updateKeys)) {
+                    throw new DidLogUpdaterStrategyException("Illegal update key detected, not all verification keys are allowed to rotate to.");
+                }
             } catch (UpdateKeysDidMethodParameterException e) {
                 throw new DidLogUpdaterStrategyException(e);
             }
-
-            if (!arePreRotatedUpdateKeys) {
-                throw new DidLogUpdaterStrategyException("Illegal updateKey detected");
-            }
-
         }
 
         // The second item in the input JSON array MUST be a valid ISO8601 date/time string,
-
         // and that the represented time MUST be before or equal to the current time.
         //
         // The versionTime for each log entry MUST be greater than the previous entry’s time.
@@ -438,7 +431,6 @@ public class WebVerifiableHistoryUpdater extends AbstractDidLogEntryBuilder impl
         // CAUTION "controller" property is omitted w.r.t.:
         // - https://jira.bit.admin.ch/browse/EIDSYS-352
         // - https://confluence.bit.admin.ch/display/EIDTEAM/DID+Doc+Conformity+Check
-        //didDoc.addProperty("controller", didTDW);
 
         if (this.allAuthentications().isEmpty() && this.allAssertionMethods().isEmpty()) {
             throw new IncompleteDidLogEntryBuilderException("No update will take place as no verification material is supplied whatsoever");
@@ -482,7 +474,6 @@ public class WebVerifiableHistoryUpdater extends AbstractDidLogEntryBuilder impl
         A version of the DID is an update to the contents of the resolved DIDDoc for the DID, and/or a change to the
         parameters that control the generation and verification of the DID.
         Each entry is a JSON object consisting of the following properties.
-        { "versionId": "", "versionTime": "", "parameters": {}, "state": {}, "proof" : [] }
          */
 
         // since did:tdw:0.4 ("Changes the DID log entry array to be named JSON objects or properties.")
@@ -566,9 +557,9 @@ public class WebVerifiableHistoryUpdater extends AbstractDidLogEntryBuilder impl
     private Set<String> loadNextUpdateKeys() throws DidLogUpdaterStrategyException {
         var keys = new HashSet<String>();
 
-        this.allNextKeyHashesDidMethodParameter().forEach(nextKeyHashSource -> {
-            keys.add(nextKeyHashSource.getNextKeyHash());
-        });
+        this.allNextKeyHashesDidMethodParameter().forEach(nextKeyHashSource ->
+                keys.add(nextKeyHashSource.getNextKeyHash())
+        );
 
         return keys;
     }
@@ -621,7 +612,14 @@ public class WebVerifiableHistoryUpdater extends AbstractDidLogEntryBuilder impl
         }
 
         if (this.shouldActivateKeyPreRotation() || didLogMeta.isKeyPreRotationActivated()) {
-            loadNextUpdateKeys().forEach(nextKeyHashesJsonArray::add);
+            var currentUpdateKeys = didLogMeta.getParams().getUpdateKeys().stream().map(s -> NextKeyHashesDidMethodParameter.of(s).getNextKeyHash()).collect(Collectors.toSet());
+            var nextKeyHashes = loadNextUpdateKeys();
+            for (var nextKeyHash : nextKeyHashes) {
+                if (currentUpdateKeys.contains(nextKeyHash)) {
+                    throw new DidLogUpdaterStrategyException("Rotating to currently used update key is not allowed.");
+                }
+            }
+            nextKeyHashes.forEach(nextKeyHashesJsonArray::add);
             didMethodParameters.add(NamedDidMethodParameters.NEXT_KEY_HASHES, nextKeyHashesJsonArray); // to deactivate key rotation
         }
 

--- a/src/test/data/README.md
+++ b/src/test/data/README.md
@@ -1,6 +1,7 @@
 # Test data
 
-Here is a short procedure on how to store a Ed25519 private key into the Java KeyStore (JKS) of type PKCS12, suitable for testing purposes.
+Here is a short procedure on how to store a Ed25519 private key into the Java KeyStore (JKS) of type PKCS12, suitable
+for testing purposes.
 
 Nothing but a few conventional CLI tool are required: `openssl` and `keytool`.
 
@@ -32,7 +33,8 @@ keytool -importkeystore \
     -alias         myalias
 ```
 
-By merely repeating the procedure described above, you may keep adding further (PKCS12 keystore) entries into the JKS store.
+By merely repeating the procedure described above, you may keep adding further (PKCS12 keystore) entries into the JKS
+store.
 To list all entries available in the JKS (use -v for verbose output), simply rely on the `keytool -list` command, e.g.:
 
 ```shell
@@ -55,4 +57,5 @@ myalias3, Mar 21, 2025, PrivateKeyEntry,
 Certificate fingerprint (SHA-256): EB:82:96:8D:B3:68:C5:AE:D9:59:39:46:16:30:3B:CC:7C:06:48:D6:45:BA:72:01:38:12:61:45:B1:93:F6:00
 ```
 
-:warning: **DISCLAIMER The entire key material stored in this directory is exclusively intended FOR TESTING PURPOSES and should NOT be therefore used for any other purposes.**
+:warning: **DISCLAIMER The entire key material stored in this directory is exclusively intended FOR TESTING PURPOSES and
+should NOT be therefore used for any other purposes.**

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/BlackboxIT.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/BlackboxIT.java
@@ -43,13 +43,13 @@ class BlackboxIT {
         // create proof of possession
         var didDoc = WebVerifiableHistoryDidLogMetaPeeker.peek(didLog).getDidDoc(); // assume a did:webvh log
         didDoc.getId();
-        var argsCreatePoP = new String[] {"create-pop", "-d", didLogFilePath, "-k", didDoc.getId() + "#assert-key-01", "-s", "./src/test/data/assert-key-01", "-n", nonce};
+        var argsCreatePoP = new String[]{"create-pop", "-d", didLogFilePath, "-k", didDoc.getId() + "#assert-key-01", "-s", "./src/test/data/assert-key-01", "-n", nonce};
         assertEquals(0, main.run(argsCreatePoP));
         var jwt = cliOutput.toString();
         cliOutput.reset();
 
         // verify proof of possession
-        var argsVerifyPoP = new String[] {"verify-pop", "-d", didLogFilePath, "-n", nonce, "-j", jwt};
+        var argsVerifyPoP = new String[]{"verify-pop", "-d", didLogFilePath, "-n", nonce, "-j", jwt};
         assertEquals(0, main.run(argsVerifyPoP));
         var out = cliOutput.toString();
         assertTrue(out.contains("JWT is valid"));

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/JCSHasherTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/JCSHasherTest.java
@@ -159,7 +159,7 @@ class JCSHasherTest {
             fail(e);
         }
 
-        assertEquals( "QmNpLm7YWwp1TxQ2KspuGtYrhXgSa7KqfqEvSZoTkhgdct", actual);
+        assertEquals("QmNpLm7YWwp1TxQ2KspuGtYrhXgSa7KqfqEvSZoTkhgdct", actual);
     }
 
     @Test

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/JCommanderRunnerTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/JCommanderRunnerTest.java
@@ -89,8 +89,6 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
 
         command.forceOverwrite = true;
         // REMINDER In case of CLI, omitting signingKeyPemFile/verifyingKeyPemFiles denotes key pair generation by the command itself
-        //command.signingKeyPemFile = TEST_SIGNING_KEY_FILES[0];
-        //command.verifyingKeyPemFiles = Set.of(TEST_KEY_FILES[0]);
         command.nextVerifyingKeyPemFiles = Set.of(TEST_KEY_FILES[1], TEST_KEY_FILES[2]); // denotes "key pre-rotation"
 
         assertDoesNotThrow(() -> {
@@ -111,14 +109,9 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
 
     @Test
     void testRunUpdateDidLogCommand() {
-
         var command = new UpdateDidLogCommand();
-
         command.didLogFile = writeStringToTempFile(buildInitialWebVerifiableHistoryDidLogEntry(TEST_CRYPTO_SUITE_JKS));
-
         command.signingKeyPemFile = new File(TEST_DATA_PATH_PREFIX + "private.pem"); // must match the updateKey set by the initial entry
-        // TODO Is setting command.verifyingKeyPemFiles irrelevant here?
-        command.verifyingKeyPemFiles = Set.of(new File(TEST_DATA_PATH_PREFIX + "public.pem")); // must match the updateKey set by the initial entry
 
         assertDoesNotThrow(() -> {
 
@@ -136,21 +129,16 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
 
     @Test
     void testRunUpdateDidLogCommandWithKeyPrerotation() {
-
         var command = new UpdateDidLogCommand();
-
         command.didLogFile = writeStringToTempFile(buildInitialWebVerifiableHistoryDidLogEntryWithKeyPrerotation(Set.of(
                 TEST_KEY_FILES[0] // the (single) pre-rotation key to be used when building the next DID log entry
         )));
-
         command.signingKeyPemFile = TEST_SIGNING_KEY_FILES[0]; // must match the pre-rotation key(s) set by the initial entry
         command.verifyingKeyPemFiles = Set.of(TEST_KEY_FILES[0]); // must match the pre-rotation key(s) set by the initial entry
         command.nextVerifyingKeyPemFiles = Set.of(TEST_KEY_FILES[1], TEST_KEY_FILES[2]); // denotes "key pre-rotation"
 
         assertDoesNotThrow(() -> {
-
             setKeyMaterial(command); // essential
-
             new JCommanderRunner(jCommanderBuilder
                     .addCommand(UpdateDidLogCommand.COMMAND_NAME, command)
                     .build(),
@@ -163,13 +151,10 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
 
     @Test
     void testRunUpdateDidLogCommandUsingJks() {
-
         var command = new UpdateDidLogCommand();
-
         command.didLogFile = writeStringToTempFile(
                 buildInitialWebVerifiableHistoryDidLogEntry(TEST_CRYPTO_SUITE_JKS) // matches "myalias" key from "mykeystore.jks"
         );
-
         command.jksFile = new File(TEST_DATA_PATH_PREFIX + "mykeystore.jks");
         command.jksPassword = "changeit";
         // REMINDER Setting to another key (e.g. "myalias2") should cause "Update key mismatch"
@@ -177,9 +162,7 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         // REMINDER Setting command.verifyingKeyPemFiles has no effect in this case
 
         assertDoesNotThrow(() -> {
-
             setKeyMaterial(command); // essential
-
             new JCommanderRunner(jCommanderBuilder
                     .addCommand(UpdateDidLogCommand.COMMAND_NAME, command)
                     .build(),
@@ -192,20 +175,15 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
 
     @Test
     void testRunUpdateDidLogCommandWithKeyPrerotationUsingJks() {
-
         var command = new UpdateDidLogCommand();
-
         command.didLogFile = writeStringToTempFile(buildInitialWebVerifiableHistoryDidLogEntryWithKeyPrerotation(Set.of(
                 TEST_KEY_FILES[0]
         )));
-
         command.verifyingKeyPemFiles = Set.of(TEST_KEY_FILES[0]);
         command.jksFile = new File(TEST_DATA_PATH_PREFIX + "mykeystore.jks");
         command.jksPassword = "changeit";
         command.jksAlias = "myalias"; // must match one the pre-rotation key(s) set by the initial entry
         // REMINDER Setting command.verifyingKeyPemFiles is optional, but the value MUST match one of the pre-rotation key(s) set by the initial entry
-        //command.verifyingKeyPemFiles = Set.of(TEST_KEY_FILES[0]);
-        //command.nextVerifyingKeyPemFiles = Set.of(TEST_KEY_FILES[0], TEST_KEY_FILES[1]);
 
         assertDoesNotThrow(() -> {
             setKeyMaterial(command); // essential
@@ -222,19 +200,15 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
 
     @Test
     void testMultipleRunUpdateDidLogCommandWithKeyPrerotationUsingJks() {
-
         var command1 = new UpdateDidLogCommand();
-
         command1.didLogFile = writeStringToTempFile(buildInitialWebVerifiableHistoryDidLogEntryWithKeyPrerotation(Set.of(
                 new File(TEST_DATA_PATH_PREFIX + "public.pem"), // matches "myalias" key from "mykeystore.jks"
                 TEST_KEY_FILES[0] // the key to rotate to when building the next entry
         )));
-
         command1.jksFile = new File(TEST_DATA_PATH_PREFIX + "mykeystore.jks");
         command1.jksPassword = "changeit";
         command1.jksAlias = "myalias"; // must match one the pre-rotation key(s) set by the initial entry
         // REMINDER Setting command1.verifyingKeyPemFiles is OPTIONAL, but the value MUST match one of the pre-rotation key(s) set by the initial entry
-        //command1.verifyingKeyPemFiles = Set.of(TEST_KEY_FILES[0]);
         command1.verifyingKeyPemFiles = Set.of(TEST_KEY_FILES[0], new File(TEST_DATA_PATH_PREFIX + "public.pem"));
         command1.nextVerifyingKeyPemFiles = Set.of(TEST_KEY_FILES[1]); // TEST_KEY_FILES[1] may be now also be used in the future
 
@@ -251,12 +225,9 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         assertFalse(output.isEmpty());
 
         var command2 = new UpdateDidLogCommand();
-
         command2.didLogFile = writeStringToTempFile(output.toString()); // built by the previous command1 run
         output = new StringBuilder(); // reset output buffer
-
         // CAUTION At this point, no appropriate JKS available for setting command1.jks* values, so get keys from the file system
-
         // Rotate to keypair TEST_SIGNING_KEY_FILES[1]/TEST_KEY_FILES[1]
         command2.signingKeyPemFile = TEST_SIGNING_KEY_FILES[1]; // must match one of the pre-rotation key(s) set by the initial entry
         command2.verifyingKeyPemFiles = Set.of(TEST_KEY_FILES[1]); // MUST be among pre-rotation key(s) set by the initial entry
@@ -276,10 +247,8 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         // CAUTION At this point, "key pre-rotation" is DEACTIVATED!
 
         var command3 = new UpdateDidLogCommand();
-
         command3.didLogFile = writeStringToTempFile(output.toString()); // built by the previous command1 run
         output = new StringBuilder(); // reset output buffer
-
         // CAUTION At this point, no appropriate JKS available for setting command1.jks* values, so get keys from the file system
         command3.signingKeyPemFile = TEST_SIGNING_KEY_FILES[1];
 

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/JCommanderRunnerTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/JCommanderRunnerTest.java
@@ -79,7 +79,6 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         });
 
         assertFalse(output.isEmpty());
-        //System.out.println(output);
     }
 
     @Test
@@ -108,7 +107,6 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         });
 
         assertFalse(output.isEmpty());
-        //System.out.println(output);
     }
 
     @Test
@@ -134,7 +132,6 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         });
 
         assertFalse(output.isEmpty());
-        //System.out.println(output);
     }
 
     @Test
@@ -162,7 +159,6 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         });
 
         assertFalse(output.isEmpty());
-        //System.out.println(output);
     }
 
     @Test
@@ -192,7 +188,6 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         });
 
         assertFalse(output.isEmpty());
-        //System.out.println(output);
     }
 
     @Test
@@ -225,7 +220,6 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         assertFalse(output.isEmpty());
     }
 
-    /* TODO@MP fix this test
     @Test
     void testMultipleRunUpdateDidLogCommandWithKeyPrerotationUsingJks() {
 
@@ -241,10 +235,10 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         command1.jksAlias = "myalias"; // must match one the pre-rotation key(s) set by the initial entry
         // REMINDER Setting command1.verifyingKeyPemFiles is OPTIONAL, but the value MUST match one of the pre-rotation key(s) set by the initial entry
         //command1.verifyingKeyPemFiles = Set.of(TEST_KEY_FILES[0]);
-        command1.nextVerifyingKeyPemFiles = Set.of(TEST_KEY_FILES[0], TEST_KEY_FILES[1]); // TEST_KEY_FILES[1] may be now also be used in the future
+        command1.verifyingKeyPemFiles = Set.of(TEST_KEY_FILES[0], new File(TEST_DATA_PATH_PREFIX + "public.pem"));
+        command1.nextVerifyingKeyPemFiles = Set.of(TEST_KEY_FILES[1]); // TEST_KEY_FILES[1] may be now also be used in the future
 
         assertDoesNotThrow(() -> {
-
             setKeyMaterial(command1); // essential
 
             new JCommanderRunner(jCommanderBuilder
@@ -269,7 +263,6 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         // CAUTION By leaving command2.nextVerifyingKeyPemFiles unset, "key pre-rotation" should be DEACTIVATED
 
         assertDoesNotThrow(() -> {
-
             setKeyMaterial(command2); // essential
 
             new JCommanderRunner(jCommanderBuilder
@@ -280,8 +273,6 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         });
 
         assertFalse(output.isEmpty());
-        //System.out.println(output);
-
         // CAUTION At this point, "key pre-rotation" is DEACTIVATED!
 
         var command3 = new UpdateDidLogCommand();
@@ -290,13 +281,9 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         output = new StringBuilder(); // reset output buffer
 
         // CAUTION At this point, no appropriate JKS available for setting command1.jks* values, so get keys from the file system
-
-        // Rotate back to keypair TEST_SIGNING_KEY_FILES[0]/TEST_KEY_FILES[0]
-        command3.signingKeyPemFile = TEST_SIGNING_KEY_FILES[0]; // MUST match one of the pre-rotation key(s) set by the initial entry
-        command3.verifyingKeyPemFiles = Set.of(TEST_KEY_FILES[0]); // MUST be among pre-rotation key(s) set by the initial entry
+        command3.signingKeyPemFile = TEST_SIGNING_KEY_FILES[1];
 
         assertDoesNotThrow(() -> {
-
             setKeyMaterial(command3); // essential
 
             new JCommanderRunner(jCommanderBuilder
@@ -307,7 +294,5 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         });
 
         assertFalse(output.isEmpty());
-        //System.out.println(output);
     }
-    */
 }

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/JCommanderRunnerTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/JCommanderRunnerTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 class JCommanderRunnerTest extends AbstractUtilTestBase {
 
     private StringBuilder output;
-    final private JCommander.Builder jCommanderBuilder = JCommander.newBuilder().console(new Console() {
+    private final JCommander.Builder jCommanderBuilder = JCommander.newBuilder().console(new Console() {
         @Override
         public void print(CharSequence charSequence) {
         }
@@ -201,10 +201,10 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         var command = new UpdateDidLogCommand();
 
         command.didLogFile = writeStringToTempFile(buildInitialWebVerifiableHistoryDidLogEntryWithKeyPrerotation(Set.of(
-                new File(TEST_DATA_PATH_PREFIX + "public.pem"), // matches "myalias" key from "mykeystore.jks"
                 TEST_KEY_FILES[0]
         )));
 
+        command.verifyingKeyPemFiles = Set.of(TEST_KEY_FILES[0]);
         command.jksFile = new File(TEST_DATA_PATH_PREFIX + "mykeystore.jks");
         command.jksPassword = "changeit";
         command.jksAlias = "myalias"; // must match one the pre-rotation key(s) set by the initial entry
@@ -213,7 +213,6 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         //command.nextVerifyingKeyPemFiles = Set.of(TEST_KEY_FILES[0], TEST_KEY_FILES[1]);
 
         assertDoesNotThrow(() -> {
-
             setKeyMaterial(command); // essential
 
             new JCommanderRunner(jCommanderBuilder
@@ -224,9 +223,9 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         });
 
         assertFalse(output.isEmpty());
-        //System.out.println(output);
     }
 
+    /* TODO@MP fix this test
     @Test
     void testMultipleRunUpdateDidLogCommandWithKeyPrerotationUsingJks() {
 
@@ -256,7 +255,6 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         });
 
         assertFalse(output.isEmpty());
-        //System.out.println(output);
 
         var command2 = new UpdateDidLogCommand();
 
@@ -267,7 +265,7 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
 
         // Rotate to keypair TEST_SIGNING_KEY_FILES[1]/TEST_KEY_FILES[1]
         command2.signingKeyPemFile = TEST_SIGNING_KEY_FILES[1]; // must match one of the pre-rotation key(s) set by the initial entry
-        command2.verifyingKeyPemFiles = Set.of(TEST_KEY_FILES[0], TEST_KEY_FILES[1]); // MUST be among pre-rotation key(s) set by the initial entry
+        command2.verifyingKeyPemFiles = Set.of(TEST_KEY_FILES[1]); // MUST be among pre-rotation key(s) set by the initial entry
         // CAUTION By leaving command2.nextVerifyingKeyPemFiles unset, "key pre-rotation" should be DEACTIVATED
 
         assertDoesNotThrow(() -> {
@@ -311,4 +309,5 @@ class JCommanderRunnerTest extends AbstractUtilTestBase {
         assertFalse(output.isEmpty());
         //System.out.println(output);
     }
+    */
 }

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/TdwDeactivatorTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/TdwDeactivatorTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -26,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.*;
 class TdwDeactivatorTest extends AbstractUtilTestBase {
 
     private static void assertDeactivatedDidLogEntry(String didLogEntry, String didLog) {
-
         assertNotNull(didLogEntry);
         assertTrue(JsonParser.parseString(didLogEntry).isJsonArray());
         JsonArray jsonArray = JsonParser.parseString(didLogEntry).getAsJsonArray();
@@ -114,7 +111,7 @@ class TdwDeactivatorTest extends AbstractUtilTestBase {
                 ["2-Qmci5evTbELsi7nQzp2mM6e7G7DUyobYGVmRAmR59SGijZ","2012-12-12T12:12:13Z",{"deactivated":true,"updateKeys":[]},{"value":{"id":"did:tdw:QmYY7o6wRFPBYfeKK4N7U4TGpXUbgwppG1zKVELxYSuDci:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085"}},[{"type":"DataIntegrityProof","cryptosuite":"eddsa-jcs-2022","created":"2012-12-12T12:12:13Z","verificationMethod":"did:key:z6MkvdAjfVZ2CWa38V2VgZvZVjSkENZpiuiV5gyRKsXDA8UP#z6MkvdAjfVZ2CWa38V2VgZvZVjSkENZpiuiV5gyRKsXDA8UP","proofPurpose":"authentication","challenge":"2-Qmci5evTbELsi7nQzp2mM6e7G7DUyobYGVmRAmR59SGijZ","proofValue":"z2zNDbYy1421CToqk5WAXsdAWBL2hHf1xPAm9TvrDA5dsHSgdpz4SBV29UnhanEhbc1RmpUwTYBHFRxC58YrXVCs1"}]]
                 """.contains(finalUpdatedDidLog));
 
-        var e = assertThrowsExactly(DidLogMetaPeekerException.class,() -> {
+        var e = assertThrowsExactly(DidLogMetaPeekerException.class, () -> {
             TdwDidLogMetaPeeker.peek(finalUpdatedDidLog); // should throw exception as did log has been deactivated
         });
         assertTrue(e.getMessage().contains("Document has been deactivated"));
@@ -190,7 +187,7 @@ class TdwDeactivatorTest extends AbstractUtilTestBase {
 
     @DisplayName("Deactivating DID log without cryptographic suite throws IncompleteDidLogEntryBuilderException")
     @Test
-    public void testDeactivateDidLogWithoutCryptographicSuiteThrowsIncompleteDidLogEntryBuilderException() {
+    void testDeactivateDidLogWithoutCryptographicSuiteThrowsIncompleteDidLogEntryBuilderException() {
 
         var initialDidLogEntry = buildInitialTdwDidLogEntry(TEST_CRYPTO_SUITE);
 

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/TdwDeactivatorTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/TdwDeactivatorTest.java
@@ -3,10 +3,12 @@ package ch.admin.bj.swiyu.didtoolbox;
 import ch.admin.bj.swiyu.didtoolbox.context.DidLogDeactivatorStrategyException;
 import ch.admin.bj.swiyu.didtoolbox.context.DidLogUpdaterStrategyException;
 import ch.admin.bj.swiyu.didtoolbox.context.IncompleteDidLogEntryBuilderException;
+import ch.admin.bj.swiyu.didtoolbox.model.DidLogMetaPeekerException;
 import ch.admin.bj.swiyu.didtoolbox.model.NamedDidMethodParameters;
 import ch.admin.bj.swiyu.didtoolbox.model.TdwDidLogMetaPeeker;
 import ch.admin.bj.swiyu.didtoolbox.vc_data_integrity.EdDsaJcs2022VcDataIntegrityCryptographicSuite;
 import ch.admin.eid.didresolver.Did;
+import ch.admin.eid.didresolver.DidResolveException;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.DisplayName;
@@ -23,33 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @SuppressWarnings("PMD")
 class TdwDeactivatorTest extends AbstractUtilTestBase {
 
-    private static Collection<Object[]> keys() {
-        return Arrays.asList(new String[][]{
-                /*
-                All lines in the private/public matrix were generated using openssl command by running the following script:
-
-                openssl genpkey -algorithm ed25519 -out private.pem
-                openssl pkey -inform pem -in private.pem -outform der -out private.der
-                cat private.pem | openssl pkey -pubout -outform der -out public.der
-                cat private.pem | openssl pkey -pubout -out public.pem
-                secret_key_multibase=z$(echo 8026$(xxd -plain -cols 32 -s -32 private.der) | xxd -r -p | bs58)
-                public_key_multibase=z$(echo ed01$(xxd -plain -cols 32 -s -32 public.der)  | xxd -r -p | bs58)
-                echo "{\"${secret_key_multibase}\", \"${public_key_multibase}\", \"\"\"\n$(cat public.pem)\n\"\"\"}"
-                 */
-                {"z6MkmwdD6L2F3nZPFDmE5VwfBctqz3iRK3sufLQD7KeqeRmn", "z6Mkk3HuYK5Vah4BjBgHYZtbFzGHufw9TWDgBcXeEtjJEesW", """
------BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAUwJJXsOciz7/TGdT2Osy0nOCqEL0oO67m0P3elFU9D0=
------END PUBLIC KEY-----
-"""},
-                {"z6Mks1E1R9Ec3sQpFAe848dHuniKvgVRibSUoBGgk8QFgdeK", "z6MkfsYSSNJ3vWFceenzLfASHMcYk7e3dEza6vz1RZcyRfcR", """
------BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAFRQpul8Rf/bxGK2ku4Loo8i7O1H/bvE7+U6RrQahOX4=
------END PUBLIC KEY-----
-"""},
-        });
-    }
-
-    private static void assertDeactivatedDidLogEntry(String didLogEntry) {
+    private static void assertDeactivatedDidLogEntry(String didLogEntry, String didLog) {
 
         assertNotNull(didLogEntry);
         assertTrue(JsonParser.parseString(didLogEntry).isJsonArray());
@@ -76,6 +52,12 @@ MCowBQYDK2VwAyEAFRQpul8Rf/bxGK2ku4Loo8i7O1H/bvE7+U6RrQahOX4=
         var proof = proofs.getAsJsonArray().get(0);
         assertTrue(proof.isJsonObject());
         assertTrue(proof.getAsJsonObject().has("proofValue"));
+
+        var exc = assertThrowsExactly(DidResolveException.InvalidDidDocument.class, () -> {
+            var did = new Did(didDoc.get("id").getAsString());
+            did.resolveAll(didLog); // sanity check
+        });
+        assertTrue(exc.getMessage().contains("Document has been deactivated"));
     }
 
     @Test
@@ -123,23 +105,19 @@ MCowBQYDK2VwAyEAFRQpul8Rf/bxGK2ku4Loo8i7O1H/bvE7+U6RrQahOX4=
                     .deactivateDidLog(deactivatedDidLog.toString(), ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(1))); // MUT
         });
 
-        assertDeactivatedDidLogEntry(nextLogEntry.get());
-
         deactivatedDidLog.append(nextLogEntry.get()).append(System.lineSeparator());
-
         var finalUpdatedDidLog = deactivatedDidLog.toString().trim(); // trimming due to a closing line separator
 
-        //System.out.println(finalUpdatedDidLog); // checkpoint
-
+        assertDeactivatedDidLogEntry(nextLogEntry.get(), finalUpdatedDidLog);
         assertTrue("""
                 ["1-QmNUGbKzhqUyuCRmt537qxpQEU5LAGm7udreBhH9QxPxYJ","2012-12-12T12:12:12Z",{"method":"did:tdw:0.3","scid":"QmYY7o6wRFPBYfeKK4N7U4TGpXUbgwppG1zKVELxYSuDci","updateKeys":["z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2","z6MkvdAjfVZ2CWa38V2VgZvZVjSkENZpiuiV5gyRKsXDA8UP"],"portable":false},{"value":{"id":"did:tdw:QmYY7o6wRFPBYfeKK4N7U4TGpXUbgwppG1zKVELxYSuDci:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085","authentication":["did:tdw:QmYY7o6wRFPBYfeKK4N7U4TGpXUbgwppG1zKVELxYSuDci:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085#my-auth-key-01"],"assertionMethod":["did:tdw:QmYY7o6wRFPBYfeKK4N7U4TGpXUbgwppG1zKVELxYSuDci:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085#my-assert-key-01"],"verificationMethod":[{"id":"did:tdw:QmYY7o6wRFPBYfeKK4N7U4TGpXUbgwppG1zKVELxYSuDci:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085#my-auth-key-01","controller":"did:tdw:QmYY7o6wRFPBYfeKK4N7U4TGpXUbgwppG1zKVELxYSuDci:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085","type":"JsonWebKey2020","publicKeyJwk":{"kty":"EC","crv":"P-256","kid":"my-auth-key-01","x":"-MUDoZjNImUbo0vNmdAqhAOPdJoptUC0tlK9xvLrqDg","y":"Djlu_TF69xQF5_L3px2FmCDQksM_fIp6kKbHRQLVIb0"}},{"id":"did:tdw:QmYY7o6wRFPBYfeKK4N7U4TGpXUbgwppG1zKVELxYSuDci:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085#my-assert-key-01","controller":"did:tdw:QmYY7o6wRFPBYfeKK4N7U4TGpXUbgwppG1zKVELxYSuDci:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085","type":"JsonWebKey2020","publicKeyJwk":{"kty":"EC","crv":"P-256","kid":"my-assert-key-01","x":"wdET0dp6vq59s1yyVh_XXyIPPU9Co7PlcTPMRRXx85Y","y":"eThC9-NetN-oXA5WU0Dn0eed7fgHtsXs2E3mU82pA9k"}}]}},[{"type":"DataIntegrityProof","cryptosuite":"eddsa-jcs-2022","created":"2012-12-12T12:12:12Z","verificationMethod":"did:key:z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2#z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2","proofPurpose":"authentication","challenge":"1-QmNUGbKzhqUyuCRmt537qxpQEU5LAGm7udreBhH9QxPxYJ","proofValue":"zEYSn9V5casGJH9wUCJDJLHqzTjTQDL11iP3MTzii8RoWdZpbhdYdV9jPTHW8gy9BGS7PweqUVDkaSpGtxUETFmL"}]]
                 ["2-Qmci5evTbELsi7nQzp2mM6e7G7DUyobYGVmRAmR59SGijZ","2012-12-12T12:12:13Z",{"deactivated":true,"updateKeys":[]},{"value":{"id":"did:tdw:QmYY7o6wRFPBYfeKK4N7U4TGpXUbgwppG1zKVELxYSuDci:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085"}},[{"type":"DataIntegrityProof","cryptosuite":"eddsa-jcs-2022","created":"2012-12-12T12:12:13Z","verificationMethod":"did:key:z6MkvdAjfVZ2CWa38V2VgZvZVjSkENZpiuiV5gyRKsXDA8UP#z6MkvdAjfVZ2CWa38V2VgZvZVjSkENZpiuiV5gyRKsXDA8UP","proofPurpose":"authentication","challenge":"2-Qmci5evTbELsi7nQzp2mM6e7G7DUyobYGVmRAmR59SGijZ","proofValue":"z2zNDbYy1421CToqk5WAXsdAWBL2hHf1xPAm9TvrDA5dsHSgdpz4SBV29UnhanEhbc1RmpUwTYBHFRxC58YrXVCs1"}]]
                 """.contains(finalUpdatedDidLog));
 
-        assertDoesNotThrow(() -> {
-            assertEquals(2, TdwDidLogMetaPeeker.peek(finalUpdatedDidLog).getLastVersionNumber()); // there should be another entry i.e. one more
-            new Did(TdwDidLogMetaPeeker.peek(initialDidLogEntry).getDidDoc().getId()).resolveAll(finalUpdatedDidLog); // the ultimate test
+        var e = assertThrowsExactly(DidLogMetaPeekerException.class,() -> {
+            TdwDidLogMetaPeeker.peek(finalUpdatedDidLog); // should throw exception as did log has been deactivated
         });
+        assertTrue(e.getMessage().contains("Document has been deactivated"));
     }
 
     @Test
@@ -148,7 +126,7 @@ MCowBQYDK2VwAyEAFRQpul8Rf/bxGK2ku4Loo8i7O1H/bvE7+U6RrQahOX4=
         var initialDidLogEntry = buildInitialTdwDidLogEntry(TEST_CRYPTO_SUITE);
 
         // CAUTION The line separator is appended intentionally - to be able to reproduce the case with multiple line separators
-        StringBuilder deactivatedDidLog = new StringBuilder(initialDidLogEntry).append(System.lineSeparator());
+        StringBuilder didLogToDeactivate = new StringBuilder(initialDidLogEntry).append(System.lineSeparator());
 
         AtomicReference<String> nextLogEntry = new AtomicReference<>();
         assertDoesNotThrow(() -> {
@@ -157,22 +135,23 @@ MCowBQYDK2VwAyEAFRQpul8Rf/bxGK2ku4Loo8i7O1H/bvE7+U6RrQahOX4=
                     .build()
                     // The versionTime for each log entry MUST be greater than the previous entry’s time.
                     // The versionTime of the last entry MUST be earlier than the current time.
-                    .deactivateDidLog(deactivatedDidLog.toString(), ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(1))); // MUT
+                    .deactivateDidLog(didLogToDeactivate.toString(), ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(1))); // MUT
         });
 
-        assertDeactivatedDidLogEntry(nextLogEntry.get());
+        var didLogDeactivated = new StringBuilder(initialDidLogEntry).append(System.lineSeparator()).append(nextLogEntry.get()).toString();
+        assertDeactivatedDidLogEntry(nextLogEntry.get(), didLogDeactivated);
 
         // Try updating the DID log
         var updaterExc = assertThrowsExactly(DidLogUpdaterStrategyException.class, () -> {
             TdwUpdater.builder()
                     .cryptographicSuite(TEST_CRYPTO_SUITE)
                     .build()
-                    .updateDidLog(new StringBuilder(initialDidLogEntry).append(System.lineSeparator()).append(nextLogEntry.get()).toString(),
+                    .updateDidLog(didLogDeactivated,
                             // The versionTime for each log entry MUST be greater than the previous entry’s time.
                             // The versionTime of the last entry MUST be earlier than the current time.
                             ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(2));
         });
-        assertEquals("DID already deactivated", updaterExc.getMessage());
+        assertTrue(updaterExc.getMessage().contains("Document has been deactivated"));
     }
 
     @Test
@@ -181,7 +160,7 @@ MCowBQYDK2VwAyEAFRQpul8Rf/bxGK2ku4Loo8i7O1H/bvE7+U6RrQahOX4=
         var initialDidLogEntry = buildInitialTdwDidLogEntry(TEST_CRYPTO_SUITE);
 
         // CAUTION The line separator is appended intentionally - to be able to reproduce the case with multiple line separators
-        StringBuilder deactivatedDidLog = new StringBuilder(initialDidLogEntry).append(System.lineSeparator());
+        StringBuilder didLogToDeactivate = new StringBuilder(initialDidLogEntry).append(System.lineSeparator());
 
         AtomicReference<String> nextLogEntry = new AtomicReference<>();
         assertDoesNotThrow(() -> {
@@ -190,12 +169,12 @@ MCowBQYDK2VwAyEAFRQpul8Rf/bxGK2ku4Loo8i7O1H/bvE7+U6RrQahOX4=
                     .build()
                     // The versionTime for each log entry MUST be greater than the previous entry’s time.
                     // The versionTime of the last entry MUST be earlier than the current time.
-                    .deactivateDidLog(deactivatedDidLog.toString(), ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(1))); // MUT
+                    .deactivateDidLog(didLogToDeactivate.toString(), ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(1))); // MUT
         });
 
-        assertDeactivatedDidLogEntry(nextLogEntry.get());
+        var didLogDeactivated = didLogToDeactivate.append(nextLogEntry.get()).append(System.lineSeparator()).toString();
 
-        deactivatedDidLog.append(nextLogEntry.get()).append(System.lineSeparator());
+        assertDeactivatedDidLogEntry(nextLogEntry.get(), didLogDeactivated);
 
         // trying to deactivate it again should fail
         var exc = assertThrowsExactly(DidLogDeactivatorStrategyException.class, () -> {
@@ -204,9 +183,9 @@ MCowBQYDK2VwAyEAFRQpul8Rf/bxGK2ku4Loo8i7O1H/bvE7+U6RrQahOX4=
                     .build()
                     // The versionTime for each log entry MUST be greater than the previous entry’s time.
                     // The versionTime of the last entry MUST be earlier than the current time.
-                    .deactivateDidLog(deactivatedDidLog.toString(), ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(2))); // MUT
+                    .deactivateDidLog(didLogToDeactivate.toString(), ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(2))); // MUT
         });
-        assertEquals("DID already deactivated", exc.getMessage());
+        assertTrue(exc.getMessage().contains("Document has been deactivated"));
     }
 
     @DisplayName("Deactivating DID log without cryptographic suite throws IncompleteDidLogEntryBuilderException")

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/context/DidLogUpdaterContextTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/context/DidLogUpdaterContextTest.java
@@ -1,13 +1,15 @@
 package ch.admin.bj.swiyu.didtoolbox.context;
 
 import ch.admin.bj.swiyu.didtoolbox.AbstractUtilTestBase;
-import ch.admin.bj.swiyu.didtoolbox.model.DidMethodEnum;
-import ch.admin.bj.swiyu.didtoolbox.model.NextKeyHashesDidMethodParameter;
-import ch.admin.bj.swiyu.didtoolbox.model.UpdateKeysDidMethodParameter;
+import ch.admin.bj.swiyu.didtoolbox.RandomEd25519KeyStore;
+import ch.admin.bj.swiyu.didtoolbox.model.*;
 import ch.admin.bj.swiyu.didtoolbox.vc_data_integrity.EdDsaJcs2022VcDataIntegrityCryptographicSuite;
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.Set;
 
@@ -132,63 +134,62 @@ class DidLogUpdaterContextTest extends AbstractUtilTestBase {
         assertTrue(exc.getMessage().contains("Update key mismatch"));
     }
 
-    /* TODO@MP fix test
     @DisplayName("Multiple updates of DID log using various pre-rotation keys")
     @Test
-    void testMultipleUpdateDidLogWithKeyPrerotation() {
+    void testMultipleUpdateDidLogWithKeyPrerotation() throws Exception {
+        var crytpoSuite = RandomEd25519KeyStore.cryptographicSuite();
+        var currentUpdateKey = RandomEd25519KeyStore.rotate().getPublicKey();
 
-        assertDoesNotThrow(() -> {
+        // build initial DID log entry
+        // initial (by default, did:webvh:1.0) DID log entry (featuring a pre-rotation key)
+        var initialDidLog = DidLogCreatorContext.builder()
+                        .cryptographicSuite(crytpoSuite)
+                        // IMPORTANT Calling this method activates key pre-rotation
+                        .nextKeyHashesDidMethodParameter(Set.of(
+                                // get a whole another pre-rotation key to be used when building the next DID log entry.
+                                // Bear in mind, after the key store "rotation", all its (static) helpers "point" to the next/another key in the store
+                                NextKeyHashesDidMethodParameter.of(currentUpdateKey)
+                                // REMINDER Indeed, you may keep adding more keys this way - beware that some of them
+                                //          MUST entirely match the "updateKeys" values in the DID log next entry
+                                //,NextKeyHashesDidMethodParameter.of(RandomEd25519KeyStore.rotate().getPublicKey())
+                                //,NextKeyHashesDidMethodParameter.of(RandomEd25519KeyStore.rotate().getPublicKey())
+                        ))
+                        .assertionMethods(TEST_ASSERTION_METHODS)
+                        .authentications(TEST_AUTHENTICATIONS)
+                        .build()
+                        .create(URL.of(new URI(TEST_DID_URL), null));// should not throw DidLogCreatorStrategyException
+        var didLog = new StringBuilder(initialDidLog).append(System.lineSeparator());
 
-            // build initial DID log entry
-            var didLog = new StringBuilder(
-                    // initial (by default, did:webvh:1.0) DID log entry (featuring a pre-rotation key)
-                    DidLogCreatorContext.builder()
-                            .cryptographicSuite(RandomEd25519KeyStore.cryptographicSuite())
-                            // IMPORTANT Calling this method activates key pre-rotation
+        assertTrue(JsonParser.parseString(didLog.toString()).getAsJsonObject().get("parameters").getAsJsonObject().has("updateKeys")); // denotes key pre-rotation
+
+        // Update the DID log by adding as many entries as there are keys in the store.
+        // Keep "rotating" (pre-rotation) keys while updating
+        var i = 0;
+        while (i++ < RandomEd25519KeyStore.getCapacity()) {
+            crytpoSuite = RandomEd25519KeyStore.cryptographicSuite(); // get crypto suite before rotating keys
+            var nextUpdateKey = RandomEd25519KeyStore.rotate().getPublicKey();
+            didLog.append(
+                    // next DID log entry
+                    DidLogUpdaterContext.builder()
+                            // switch to the key defined by the "nextKeyHashes" from the previous entry (the key store is already "rotated" earlier)
+                            .cryptographicSuite(crytpoSuite)
+                            .assertionMethods(Set.of(VerificationMethod.of("my-assert-key-0" + i, Path.of(TEST_DATA_PATH_PREFIX + "assert-key-01.pub"))))
+                            .authentications(Set.of(VerificationMethod.of("my-auth-key-0" + i, Path.of(TEST_DATA_PATH_PREFIX + "auth-key-01.pub"))))
+                            // Prepare ("rotate" to) another pre-rotation key to be used when building the next DID log entry
+                            .updateKeysDidMethodParameter(Set.of(UpdateKeysDidMethodParameter.of(currentUpdateKey)))
                             .nextKeyHashesDidMethodParameter(Set.of(
-                                    // get a whole another pre-rotation key to be used when building the next DID log entry.
                                     // Bear in mind, after the key store "rotation", all its (static) helpers "point" to the next/another key in the store
-                                    NextKeyHashesDidMethodParameter.of(RandomEd25519KeyStore.rotate().getPublicKey())
+                                    //RandomEd25519KeyStore.rotate().asNextKeyHashesDidMethodParameter()
+                                    NextKeyHashesDidMethodParameter.of(nextUpdateKey)
                                     // REMINDER Indeed, you may keep adding more keys this way - beware that some of them
                                     //          MUST entirely match the "updateKeys" values in the DID log next entry
                                     //,NextKeyHashesDidMethodParameter.of(RandomEd25519KeyStore.rotate().getPublicKey())
                                     //,NextKeyHashesDidMethodParameter.of(RandomEd25519KeyStore.rotate().getPublicKey())
                             ))
-                            .assertionMethods(TEST_ASSERTION_METHODS)
-                            .authentications(TEST_AUTHENTICATIONS)
                             .build()
-                            .create(URL.of(new URI(TEST_DID_URL), null)) // should not throw DidLogCreatorStrategyException
+                            .update(didLog.toString()) // should not throw DidLogUpdaterStrategyException
             ).append(System.lineSeparator());
-
-            assertTrue(JsonParser.parseString(didLog.toString()).getAsJsonObject().get("parameters").getAsJsonObject().has("updateKeys")); // denotes key pre-rotation
-
-            // Update the DID log by adding as many entries as there are keys in the store.
-            // Keep "rotating" (pre-rotation) keys while updating
-            var i = 0;
-            while (i++ < RandomEd25519KeyStore.getCapacity()) {
-
-                didLog.append(
-                        // next DID log entry
-                        DidLogUpdaterContext.builder()
-                                // switch to the key defined by the "nextKeyHashes" from the previous entry (the key store is already "rotated" earlier)
-                                .cryptographicSuite(RandomEd25519KeyStore.cryptographicSuite())
-                                .assertionMethods(Set.of(VerificationMethod.of("my-assert-key-0" + i, Path.of(TEST_DATA_PATH_PREFIX + "assert-key-01.pub"))))
-                                .authentications(Set.of(VerificationMethod.of("my-auth-key-0" + i, Path.of(TEST_DATA_PATH_PREFIX + "auth-key-01.pub"))))
-                                // Prepare ("rotate" to) another pre-rotation key to be used when building the next DID log entry
-                                .nextKeyHashesDidMethodParameter(Set.of(
-                                        // Bear in mind, after the key store "rotation", all its (static) helpers "point" to the next/another key in the store
-                                        //RandomEd25519KeyStore.rotate().asNextKeyHashesDidMethodParameter()
-                                        NextKeyHashesDidMethodParameter.of(RandomEd25519KeyStore.rotate().getPublicKey())
-                                        // REMINDER Indeed, you may keep adding more keys this way - beware that some of them
-                                        //          MUST entirely match the "updateKeys" values in the DID log next entry
-                                        //,NextKeyHashesDidMethodParameter.of(RandomEd25519KeyStore.rotate().getPublicKey())
-                                        //,NextKeyHashesDidMethodParameter.of(RandomEd25519KeyStore.rotate().getPublicKey())
-                                ))
-                                .build()
-                                .update(didLog.toString()) // should not throw DidLogUpdaterStrategyException
-                ).append(System.lineSeparator());
-            }
-        });
+            currentUpdateKey = nextUpdateKey;
+        }
     }
-     */
 }

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/context/DidLogUpdaterContextTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/context/DidLogUpdaterContextTest.java
@@ -143,21 +143,21 @@ class DidLogUpdaterContextTest extends AbstractUtilTestBase {
         // build initial DID log entry
         // initial (by default, did:webvh:1.0) DID log entry (featuring a pre-rotation key)
         var initialDidLog = DidLogCreatorContext.builder()
-                        .cryptographicSuite(crytpoSuite)
-                        // IMPORTANT Calling this method activates key pre-rotation
-                        .nextKeyHashesDidMethodParameter(Set.of(
-                                // get a whole another pre-rotation key to be used when building the next DID log entry.
-                                // Bear in mind, after the key store "rotation", all its (static) helpers "point" to the next/another key in the store
-                                NextKeyHashesDidMethodParameter.of(currentUpdateKey)
-                                // REMINDER Indeed, you may keep adding more keys this way - beware that some of them
-                                //          MUST entirely match the "updateKeys" values in the DID log next entry
-                                //,NextKeyHashesDidMethodParameter.of(RandomEd25519KeyStore.rotate().getPublicKey())
-                                //,NextKeyHashesDidMethodParameter.of(RandomEd25519KeyStore.rotate().getPublicKey())
-                        ))
-                        .assertionMethods(TEST_ASSERTION_METHODS)
-                        .authentications(TEST_AUTHENTICATIONS)
-                        .build()
-                        .create(URL.of(new URI(TEST_DID_URL), null));// should not throw DidLogCreatorStrategyException
+                .cryptographicSuite(crytpoSuite)
+                // IMPORTANT Calling this method activates key pre-rotation
+                .nextKeyHashesDidMethodParameter(Set.of(
+                        // get a whole another pre-rotation key to be used when building the next DID log entry.
+                        // Bear in mind, after the key store "rotation", all its (static) helpers "point" to the next/another key in the store
+                        NextKeyHashesDidMethodParameter.of(currentUpdateKey)
+                        // REMINDER Indeed, you may keep adding more keys this way - beware that some of them
+                        //          MUST entirely match the "updateKeys" values in the DID log next entry
+                        //,NextKeyHashesDidMethodParameter.of(RandomEd25519KeyStore.rotate().getPublicKey())
+                        //,NextKeyHashesDidMethodParameter.of(RandomEd25519KeyStore.rotate().getPublicKey())
+                ))
+                .assertionMethods(TEST_ASSERTION_METHODS)
+                .authentications(TEST_AUTHENTICATIONS)
+                .build()
+                .create(URL.of(new URI(TEST_DID_URL), null));// should not throw DidLogCreatorStrategyException
         var didLog = new StringBuilder(initialDidLog).append(System.lineSeparator());
 
         assertTrue(JsonParser.parseString(didLog.toString()).getAsJsonObject().get("parameters").getAsJsonObject().has("updateKeys")); // denotes key pre-rotation

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/context/DidLogUpdaterContextTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/context/DidLogUpdaterContextTest.java
@@ -1,18 +1,13 @@
 package ch.admin.bj.swiyu.didtoolbox.context;
 
 import ch.admin.bj.swiyu.didtoolbox.AbstractUtilTestBase;
-import ch.admin.bj.swiyu.didtoolbox.RandomEd25519KeyStore;
 import ch.admin.bj.swiyu.didtoolbox.model.DidMethodEnum;
 import ch.admin.bj.swiyu.didtoolbox.model.NextKeyHashesDidMethodParameter;
 import ch.admin.bj.swiyu.didtoolbox.model.UpdateKeysDidMethodParameter;
-import ch.admin.bj.swiyu.didtoolbox.model.VerificationMethod;
 import ch.admin.bj.swiyu.didtoolbox.vc_data_integrity.EdDsaJcs2022VcDataIntegrityCryptographicSuite;
-import com.google.gson.JsonParser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.net.URI;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.Set;
 
@@ -137,6 +132,7 @@ class DidLogUpdaterContextTest extends AbstractUtilTestBase {
         assertTrue(exc.getMessage().contains("Update key mismatch"));
     }
 
+    /* TODO@MP fix test
     @DisplayName("Multiple updates of DID log using various pre-rotation keys")
     @Test
     void testMultipleUpdateDidLogWithKeyPrerotation() {
@@ -194,4 +190,5 @@ class DidLogUpdaterContextTest extends AbstractUtilTestBase {
             }
         });
     }
+     */
 }

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryCreatorTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryCreatorTest.java
@@ -4,10 +4,7 @@ import ch.admin.bj.swiyu.didtoolbox.AbstractUtilTestBase;
 import ch.admin.bj.swiyu.didtoolbox.JCSHasher;
 import ch.admin.bj.swiyu.didtoolbox.context.DidLogCreatorContext;
 import ch.admin.bj.swiyu.didtoolbox.context.IncompleteDidLogEntryBuilderException;
-import ch.admin.bj.swiyu.didtoolbox.model.DidMethodEnum;
-import ch.admin.bj.swiyu.didtoolbox.model.NamedDidMethodParameters;
-import ch.admin.bj.swiyu.didtoolbox.model.NextKeyHashesDidMethodParameter;
-import ch.admin.bj.swiyu.didtoolbox.model.UpdateKeysDidMethodParameter;
+import ch.admin.bj.swiyu.didtoolbox.model.*;
 import ch.admin.bj.swiyu.didtoolbox.vc_data_integrity.EdDsaJcs2022VcDataIntegrityCryptographicSuite;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Assertions;
@@ -130,7 +127,7 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
     @DisplayName("Building did:webvh log entry for various identifierRegistryUrl variants (multiple updateKeys) with activated prerotation")
     @ParameterizedTest(name = "For identifierRegistryUrl: {0}")
     @MethodSource("identifierRegistryUrl")
-    void testCreateDidLogWithMultipleUpdateKeysAndActivatedPrerotation(URL identifierRegistryUrl) {
+    void testCreateDidLogWithMultipleUpdateKeysAndActivatedPrerotation(URL identifierRegistryUrl) throws UpdateKeysDidMethodParameterException, NextKeyHashesDidMethodParameterException {
 
         AtomicReference<String> didLogEntry = new AtomicReference<>();
 
@@ -139,7 +136,7 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
             didLogEntry.set(WebVerifiableHistoryCreator.builder()
                     .cryptographicSuite(new EdDsaJcs2022VcDataIntegrityCryptographicSuite())
                     .updateKeysDidMethodParameter(Set.of(UpdateKeysDidMethodParameter.of(Path.of("src/test/data/public.pem"))))
-                    .nextKeyHashesDidMethodParameter(Set.of(NextKeyHashesDidMethodParameter.of(Path.of("src/test/data/public.pem")))) // activate prerotation by adding one of the 'updateKeys'
+                    .nextKeyHashesDidMethodParameter(Set.of(NextKeyHashesDidMethodParameter.of(Path.of("src/test/data/public01.pem")))) // activate prerotation by adding one of the 'updateKeys'
                     .authentications(TEST_AUTHENTICATIONS)
                     .assertionMethods(TEST_ASSERTION_METHODS)
                     .build()
@@ -153,8 +150,8 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
         assertEquals(2, params.get(NamedDidMethodParameters.UPDATE_KEYS).getAsJsonArray().size()); // Effectively, it is only 2 distinct keys...
         assertFalse(params.get(NamedDidMethodParameters.NEXT_KEY_HASHES).getAsJsonArray().isEmpty());
         assertEquals(1, params.get(NamedDidMethodParameters.NEXT_KEY_HASHES).getAsJsonArray().size());
-        assertEquals(NextKeyHashesDidMethodParameter.of(params.get(NamedDidMethodParameters.UPDATE_KEYS).getAsJsonArray().get(1).getAsString()).getNextKeyHash(),
-                params.get(NamedDidMethodParameters.NEXT_KEY_HASHES).getAsJsonArray().get(0).getAsString()); // MUST match the last added updateKey
+        assertEquals(UpdateKeysDidMethodParameter.of(Path.of("src/test/data/public.pem")).getUpdateKey(), params.get(NamedDidMethodParameters.UPDATE_KEYS).getAsJsonArray().get(1).getAsString());
+        assertEquals(NextKeyHashesDidMethodParameter.of(Path.of("src/test/data/public01.pem")).getNextKeyHash(), params.get(NamedDidMethodParameters.NEXT_KEY_HASHES).getAsJsonArray().get(0).getAsString());
     }
 
     @DisplayName("Building did:webvh log entry for various identifierRegistryUrl variants (multiple updateKeys) with activated prerotation")
@@ -192,7 +189,7 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
     @DisplayName("Building did:webvh log entry for various identifierRegistryUrl variants (multiple updateKeys) with activated prerotation")
     @ParameterizedTest(name = "For identifierRegistryUrl: {0}")
     @MethodSource("identifierRegistryUrl")
-    void testCreateDidLogWithMultipleUpdateKeysAndActivatedPrerotation3(URL identifierRegistryUrl) {
+    void testCreateDidLogWithMultipleUpdateKeysAndActivatedPrerotation3(URL identifierRegistryUrl) throws UpdateKeysDidMethodParameterException, NextKeyHashesDidMethodParameterException {
 
         // Now, try activating prerotation by adding a hash of whole another key to be used in the future
 
@@ -202,7 +199,7 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
             didLogEntry.set(WebVerifiableHistoryCreator.builder()
                     .cryptographicSuite(TEST_CRYPTO_SUITE_JKS)
                     .updateKeysDidMethodParameter(Set.of(UpdateKeysDidMethodParameter.of(Path.of("src/test/data/public.pem")))) // it matches the signing key, thus it should not be added to 'updateKeys'
-                    .nextKeyHashesDidMethodParameter(Set.of(NextKeyHashesDidMethodParameter.of(Path.of("src/test/data/public.pem")))) // activate prerotation by adding one of the 'updateKeys'
+                    .nextKeyHashesDidMethodParameter(Set.of(NextKeyHashesDidMethodParameter.of(Path.of("src/test/data/public01.pem")))) // activate prerotation by adding one of the 'updateKeys'
                     .authentications(TEST_AUTHENTICATIONS)
                     .assertionMethods(TEST_ASSERTION_METHODS)
                     .build()
@@ -216,8 +213,8 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
         assertEquals(1, params.get(NamedDidMethodParameters.UPDATE_KEYS).getAsJsonArray().size()); // Effectively, it is one single keys...
         assertFalse(params.get(NamedDidMethodParameters.NEXT_KEY_HASHES).getAsJsonArray().isEmpty());
         assertEquals(1, params.get(NamedDidMethodParameters.NEXT_KEY_HASHES).getAsJsonArray().size());
-        assertEquals(NextKeyHashesDidMethodParameter.of(params.get(NamedDidMethodParameters.UPDATE_KEYS).getAsJsonArray().get(0).getAsString()).getNextKeyHash(),
-                params.get(NamedDidMethodParameters.NEXT_KEY_HASHES).getAsJsonArray().get(0).getAsString()); // MUST match the last added (in this case, the only) updateKey
+        assertEquals(UpdateKeysDidMethodParameter.of(Path.of("src/test/data/public.pem")).getUpdateKey(), params.get(NamedDidMethodParameters.UPDATE_KEYS).getAsJsonArray().get(0).getAsString());
+        assertEquals(NextKeyHashesDidMethodParameter.of(Path.of("src/test/data/public01.pem")).getNextKeyHash(), params.get(NamedDidMethodParameters.NEXT_KEY_HASHES).getAsJsonArray().get(0).getAsString());
     }
 
     @DisplayName("Building did:webvh log entry for various identifierRegistryUrl variants using Java Keystore (JKS)")
@@ -262,7 +259,7 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
                     .assertionMethods(TEST_ASSERTION_METHODS)
                     .authentications(TEST_AUTHENTICATIONS)
                     .build()
-                    // CAUTION datetime is set explicitly here just to be able to run assertTrue("...".contains(didLogEntry));
+                    // CAUTION datetime is set explicitly here just to be able to get a deterministic output
                     .createDidLog(identifierRegistryUrl, ZonedDateTime.parse("2012-12-12T12:12:12Z"))); // MUT
         });
 

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryCreatorTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryCreatorTest.java
@@ -3,6 +3,8 @@ package ch.admin.bj.swiyu.didtoolbox.webvh;
 import ch.admin.bj.swiyu.didtoolbox.AbstractUtilTestBase;
 import ch.admin.bj.swiyu.didtoolbox.JCSHasher;
 import ch.admin.bj.swiyu.didtoolbox.context.DidLogCreatorContext;
+import ch.admin.bj.swiyu.didtoolbox.context.DidLogCreatorStrategyException;
+import ch.admin.bj.swiyu.didtoolbox.context.DidLogUpdaterStrategyException;
 import ch.admin.bj.swiyu.didtoolbox.context.IncompleteDidLogEntryBuilderException;
 import ch.admin.bj.swiyu.didtoolbox.model.*;
 import ch.admin.bj.swiyu.didtoolbox.vc_data_integrity.EdDsaJcs2022VcDataIntegrityCryptographicSuite;
@@ -84,7 +86,6 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
     @ParameterizedTest(name = "For identifierRegistryUrl: {0}")
     @MethodSource("identifierRegistryUrl")
     void testCreateDidLog(URL identifierRegistryUrl) {
-
         AtomicReference<String> didLogEntry = new AtomicReference<>();
         assertDoesNotThrow(() -> {
 
@@ -104,7 +105,6 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
     @ParameterizedTest(name = "For identifierRegistryUrl: {0}")
     @MethodSource("identifierRegistryUrl")
     void testCreateDidLogWithMultipleUpdateKeys(URL identifierRegistryUrl) {
-
         AtomicReference<String> didLogEntry = new AtomicReference<>();
         assertDoesNotThrow(() -> {
             // Note that all keys will all be generated here as well, as the default Ed25519SignerVerifier constructor is used implicitly
@@ -158,9 +158,7 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
     @ParameterizedTest(name = "For identifierRegistryUrl: {0}")
     @MethodSource("identifierRegistryUrl")
     void testCreateDidLogWithMultipleUpdateKeysAndActivatedPrerotation2(URL identifierRegistryUrl) {
-
         // Now, try activating prerotation by adding a hash of whole another key to be used in the future
-
         AtomicReference<String> didLogEntry = new AtomicReference<>();
 
         assertDoesNotThrow(() -> {
@@ -190,9 +188,7 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
     @ParameterizedTest(name = "For identifierRegistryUrl: {0}")
     @MethodSource("identifierRegistryUrl")
     void testCreateDidLogWithMultipleUpdateKeysAndActivatedPrerotation3(URL identifierRegistryUrl) throws UpdateKeysDidMethodParameterException, NextKeyHashesDidMethodParameterException {
-
         // Now, try activating prerotation by adding a hash of whole another key to be used in the future
-
         AtomicReference<String> didLogEntry = new AtomicReference<>();
         assertDoesNotThrow(() -> {
             // Note that all keys will all be generated here as well, as the default Ed25519SignerVerifier constructor is used implicitly
@@ -221,7 +217,6 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
     @ParameterizedTest(name = "For identifierRegistryUrl: {0}")
     @MethodSource("identifierRegistryUrl")
     void testCreateDidLogUsingJKS(URL identifierRegistryUrl) {
-
         AtomicReference<String> didLogEntry = new AtomicReference<>();
         assertDoesNotThrow(() -> {
             didLogEntry.set(WebVerifiableHistoryCreator.builder()
@@ -251,7 +246,6 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
     @ParameterizedTest(name = "For identifierRegistryUrl: {0}")
     @MethodSource("identifierRegistryUrl")
     void testCreateDidLogUsingJksWithExternalVerificationMethodKeys(URL identifierRegistryUrl) { // https://www.w3.org/TR/did-core/#assertion
-
         AtomicReference<String> didLogEntry = new AtomicReference<>();
         assertDoesNotThrow(() -> {
             didLogEntry.set(WebVerifiableHistoryCreator.builder()
@@ -285,7 +279,6 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
     @DisplayName("Building DID log entry without cryptographic suite (or verification material) throws IncompleteDidLogEntryBuilderException")
     @Test
     void testCreateDidLogWithoutCryptographicSuiteThrowsIncompleteDidLogEntryBuilderException() {
-
         var exc = assertThrowsExactly(IncompleteDidLogEntryBuilderException.class, () -> {
             WebVerifiableHistoryCreator.builder()
                     // IMPORTANT A .cryptographicSuite() call is omitted intentionally (no cryptographic suite supplied)
@@ -307,10 +300,29 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
         assertTrue(exc.getMessage().contains("No verification material"));
     }
 
+    @DisplayName("Trying to build a DID log entry with same update key and next key hash, should throw DidLogUpdaterStrategyException")
+    @Test
+    void testCreateDidLogWithSameUpdateAndRotationKeyExpectingException() {
+        var e = assertThrowsExactly(DidLogCreatorStrategyException.class, () -> {
+            WebVerifiableHistoryCreator.builder()
+                    .cryptographicSuite(TEST_CRYPTO_SUITE)
+                    .authentications(TEST_AUTHENTICATIONS)
+                    .assertionMethods(TEST_ASSERTION_METHODS)
+                    .updateKeysDidMethodParameter(Set.of(
+                            UpdateKeysDidMethodParameter.of(Path.of("src/test/data/public.pem"))
+                    ))
+                    .nextKeyHashesDidMethodParameter(Set.of(
+                            NextKeyHashesDidMethodParameter.of(Path.of("src/test/data/public01.pem")),
+                            NextKeyHashesDidMethodParameter.of(Path.of("src/test/data/public.pem"))
+                    ))
+                    .build().createDidLog(new URL(TEST_DID_URL));
+        });
+        assertTrue(e.getMessage().contains("not allowed to be in both"));
+    }
+
     @DisplayName("Building did:webvh log entry from an existing DID document")
     @Test
     void testFromDidDoc() {
-
         var zdt = ZonedDateTime.now();
         assertDoesNotThrow(() -> {
             var url = identifierRegistryUrl().stream().toList();

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryCreatorTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryCreatorTest.java
@@ -4,7 +4,6 @@ import ch.admin.bj.swiyu.didtoolbox.AbstractUtilTestBase;
 import ch.admin.bj.swiyu.didtoolbox.JCSHasher;
 import ch.admin.bj.swiyu.didtoolbox.context.DidLogCreatorContext;
 import ch.admin.bj.swiyu.didtoolbox.context.DidLogCreatorStrategyException;
-import ch.admin.bj.swiyu.didtoolbox.context.DidLogUpdaterStrategyException;
 import ch.admin.bj.swiyu.didtoolbox.context.IncompleteDidLogEntryBuilderException;
 import ch.admin.bj.swiyu.didtoolbox.model.*;
 import ch.admin.bj.swiyu.didtoolbox.vc_data_integrity.EdDsaJcs2022VcDataIntegrityCryptographicSuite;
@@ -315,7 +314,7 @@ public class WebVerifiableHistoryCreatorTest extends AbstractUtilTestBase {
                             NextKeyHashesDidMethodParameter.of(Path.of("src/test/data/public01.pem")),
                             NextKeyHashesDidMethodParameter.of(Path.of("src/test/data/public.pem"))
                     ))
-                    .build().createDidLog(new URL(TEST_DID_URL));
+                    .build().createDidLog(URL.of(new URI(TEST_DID_URL), null));
         });
         assertTrue(e.getMessage().contains("not allowed to be in both"));
     }

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryDeactivatorTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryDeactivatorTest.java
@@ -116,7 +116,7 @@ class WebVerifiableHistoryDeactivatorTest extends AbstractUtilTestBase {
                 {"versionId":"2-QmQMuUUM8V7WjotLsDpwpe9ttnkPDfwMmHhCzrxpZxRZkB","versionTime":"2012-12-12T12:12:13Z","parameters":{"deactivated":true,"updateKeys":[]},"state":{"id":"did:webvh:QmdHF4ggqEDDHqaG88HNFxTSFyniV93A4nQfGNkxQ85PkX:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085","profile_version":"swiss-profile-anchor:1.0.0"},"proof":[{"type":"DataIntegrityProof","cryptosuite":"eddsa-jcs-2022","created":"2012-12-12T12:12:13Z","verificationMethod":"did:key:z6MkvdAjfVZ2CWa38V2VgZvZVjSkENZpiuiV5gyRKsXDA8UP#z6MkvdAjfVZ2CWa38V2VgZvZVjSkENZpiuiV5gyRKsXDA8UP","proofPurpose":"assertionMethod","proofValue":"z3D9PcQ41EDZp5VCxWGUcVx9E9947KnEy8GJLk57bJXxLUSwsSK1yi37iE4PTe4Ti1Svcg1epAZLtok5VmjM6wFiA"}]}
                 """.contains(finalUpdatedDidLog));
 
-        var e = assertThrowsExactly(DidLogMetaPeekerException.class,() -> {
+        var e = assertThrowsExactly(DidLogMetaPeekerException.class, () -> {
             WebVerifiableHistoryDidLogMetaPeeker.peek(finalUpdatedDidLog); // should throw exception as did log has been deactivated
         });
         assertTrue(e.getMessage().contains("Document has been deactivated"));
@@ -192,7 +192,7 @@ class WebVerifiableHistoryDeactivatorTest extends AbstractUtilTestBase {
 
     @DisplayName("Deactivating DID log without cryptographic suite throws IncompleteDidLogEntryBuilderException")
     @Test
-    public void testDeactivateDidLogWithoutCryptographicSuiteThrowsIncompleteDidLogEntryBuilderException() {
+    void testDeactivateDidLogWithoutCryptographicSuiteThrowsIncompleteDidLogEntryBuilderException() {
 
         var initialDidLogEntry = buildInitialWebVerifiableHistoryDidLogEntry(TEST_CRYPTO_SUITE);
 

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryDeactivatorTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryDeactivatorTest.java
@@ -1,6 +1,7 @@
 package ch.admin.bj.swiyu.didtoolbox.webvh;
 
 import ch.admin.bj.swiyu.didtoolbox.AbstractUtilTestBase;
+import ch.admin.bj.swiyu.didtoolbox.model.DidLogMetaPeekerException;
 import ch.admin.bj.swiyu.didtoolbox.model.ProfileVersion;
 import ch.admin.bj.swiyu.didtoolbox.context.DidLogDeactivatorStrategyException;
 import ch.admin.bj.swiyu.didtoolbox.context.DidLogUpdaterStrategyException;
@@ -9,6 +10,7 @@ import ch.admin.bj.swiyu.didtoolbox.model.NamedDidMethodParameters;
 import ch.admin.bj.swiyu.didtoolbox.model.WebVerifiableHistoryDidLogMetaPeeker;
 import ch.admin.bj.swiyu.didtoolbox.vc_data_integrity.EdDsaJcs2022VcDataIntegrityCryptographicSuite;
 import ch.admin.eid.didresolver.Did;
+import ch.admin.eid.didresolver.DidResolveException;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @SuppressWarnings({"PMD"})
 class WebVerifiableHistoryDeactivatorTest extends AbstractUtilTestBase {
 
-    private static void assertDeactivatedDidLogEntry(String didLogEntry) {
+    private static void assertDeactivatedDidLogEntry(String didLogEntry, String didLog) {
 
         assertNotNull(didLogEntry);
         assertTrue(JsonParser.parseString(didLogEntry).isJsonObject());
@@ -51,6 +53,12 @@ class WebVerifiableHistoryDeactivatorTest extends AbstractUtilTestBase {
         var proof = proofs.getAsJsonArray().get(0);
         assertTrue(proof.isJsonObject());
         assertTrue(proof.getAsJsonObject().has("proofValue"));
+
+        var exc = assertThrowsExactly(DidResolveException.InvalidDidDocument.class, () -> {
+            var did = new Did(didDoc.get("id").getAsString());
+            did.resolveAll(didLog); // sanity check
+        });
+        assertTrue(exc.getMessage().contains("Document has been deactivated"));
     }
 
     @Test
@@ -97,23 +105,21 @@ class WebVerifiableHistoryDeactivatorTest extends AbstractUtilTestBase {
                     .deactivateDidLog(deactivatedDidLog.toString(), ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(1))); // MUT
         });
 
-        assertDeactivatedDidLogEntry(nextLogEntry.get());
 
         deactivatedDidLog.append(nextLogEntry.get()).append(System.lineSeparator());
-
         var finalUpdatedDidLog = deactivatedDidLog.toString().trim(); // trimming due to a closing line separator
 
-        //System.out.println(finalUpdatedDidLog); // checkpoint
+        assertDeactivatedDidLogEntry(nextLogEntry.get(), finalUpdatedDidLog);
 
         assertTrue("""
                 {"versionId":"1-QmU71QhcuPZcswrMbb4GxM3afb5eiRjuCFk37jj2XrF8jZ","versionTime":"2012-12-12T12:12:12Z","parameters":{"method":"did:webvh:1.0","scid":"QmdHF4ggqEDDHqaG88HNFxTSFyniV93A4nQfGNkxQ85PkX","updateKeys":["z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2","z6MkvdAjfVZ2CWa38V2VgZvZVjSkENZpiuiV5gyRKsXDA8UP"],"portable":false},"state":{"id":"did:webvh:QmdHF4ggqEDDHqaG88HNFxTSFyniV93A4nQfGNkxQ85PkX:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085","profile_version":"swiss-profile-anchor:1.0.0","authentication":["did:webvh:QmdHF4ggqEDDHqaG88HNFxTSFyniV93A4nQfGNkxQ85PkX:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085#my-auth-key-01"],"assertionMethod":["did:webvh:QmdHF4ggqEDDHqaG88HNFxTSFyniV93A4nQfGNkxQ85PkX:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085#my-assert-key-01"],"verificationMethod":[{"id":"did:webvh:QmdHF4ggqEDDHqaG88HNFxTSFyniV93A4nQfGNkxQ85PkX:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085#my-auth-key-01","controller":"did:webvh:QmdHF4ggqEDDHqaG88HNFxTSFyniV93A4nQfGNkxQ85PkX:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085","type":"JsonWebKey2020","publicKeyJwk":{"kty":"EC","crv":"P-256","kid":"my-auth-key-01","x":"-MUDoZjNImUbo0vNmdAqhAOPdJoptUC0tlK9xvLrqDg","y":"Djlu_TF69xQF5_L3px2FmCDQksM_fIp6kKbHRQLVIb0"}},{"id":"did:webvh:QmdHF4ggqEDDHqaG88HNFxTSFyniV93A4nQfGNkxQ85PkX:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085#my-assert-key-01","controller":"did:webvh:QmdHF4ggqEDDHqaG88HNFxTSFyniV93A4nQfGNkxQ85PkX:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085","type":"JsonWebKey2020","publicKeyJwk":{"kty":"EC","crv":"P-256","kid":"my-assert-key-01","x":"wdET0dp6vq59s1yyVh_XXyIPPU9Co7PlcTPMRRXx85Y","y":"eThC9-NetN-oXA5WU0Dn0eed7fgHtsXs2E3mU82pA9k"}}]},"proof":[{"type":"DataIntegrityProof","cryptosuite":"eddsa-jcs-2022","created":"2012-12-12T12:12:12Z","verificationMethod":"did:key:z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2#z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2","proofPurpose":"assertionMethod","proofValue":"z4WdFmBpv4Bd4McJYu899ZeCXaP9Vx4M5mgtVX6qbX8e1bN7Z4pfCjaCtjUfXTvdR3HvqPB8BUVJufZ7Gbe5QUJw2"}]}
                 {"versionId":"2-QmQMuUUM8V7WjotLsDpwpe9ttnkPDfwMmHhCzrxpZxRZkB","versionTime":"2012-12-12T12:12:13Z","parameters":{"deactivated":true,"updateKeys":[]},"state":{"id":"did:webvh:QmdHF4ggqEDDHqaG88HNFxTSFyniV93A4nQfGNkxQ85PkX:identifier-reg.trust-infra.swiyu-int.admin.ch:api:v1:did:18fa7c77-9dd1-4e20-a147-fb1bec146085","profile_version":"swiss-profile-anchor:1.0.0"},"proof":[{"type":"DataIntegrityProof","cryptosuite":"eddsa-jcs-2022","created":"2012-12-12T12:12:13Z","verificationMethod":"did:key:z6MkvdAjfVZ2CWa38V2VgZvZVjSkENZpiuiV5gyRKsXDA8UP#z6MkvdAjfVZ2CWa38V2VgZvZVjSkENZpiuiV5gyRKsXDA8UP","proofPurpose":"assertionMethod","proofValue":"z3D9PcQ41EDZp5VCxWGUcVx9E9947KnEy8GJLk57bJXxLUSwsSK1yi37iE4PTe4Ti1Svcg1epAZLtok5VmjM6wFiA"}]}
                 """.contains(finalUpdatedDidLog));
 
-        assertDoesNotThrow(() -> {
-            assertEquals(2, WebVerifiableHistoryDidLogMetaPeeker.peek(finalUpdatedDidLog).getLastVersionNumber()); // there should be another entry i.e. one more
-            new Did(WebVerifiableHistoryDidLogMetaPeeker.peek(initialDidLogEntry).getDidDoc().getId()).resolveAll(finalUpdatedDidLog); // the ultimate test
+        var e = assertThrowsExactly(DidLogMetaPeekerException.class,() -> {
+            WebVerifiableHistoryDidLogMetaPeeker.peek(finalUpdatedDidLog); // should throw exception as did log has been deactivated
         });
+        assertTrue(e.getMessage().contains("Document has been deactivated"));
     }
 
     @Test
@@ -122,7 +128,7 @@ class WebVerifiableHistoryDeactivatorTest extends AbstractUtilTestBase {
         var initialDidLogEntry = buildInitialWebVerifiableHistoryDidLogEntry(TEST_CRYPTO_SUITE);
 
         // CAUTION The line separator is appended intentionally - to be able to reproduce the case with multiple line separators
-        StringBuilder deactivatedDidLog = new StringBuilder(initialDidLogEntry).append(System.lineSeparator());
+        StringBuilder didLogToDeactivate = new StringBuilder(initialDidLogEntry).append(System.lineSeparator());
 
         AtomicReference<String> nextLogEntry = new AtomicReference<>();
         assertDoesNotThrow(() -> {
@@ -131,22 +137,23 @@ class WebVerifiableHistoryDeactivatorTest extends AbstractUtilTestBase {
                     .build()
                     // The versionTime for each log entry MUST be greater than the previous entry’s time.
                     // The versionTime of the last entry MUST be earlier than the current time.
-                    .deactivateDidLog(deactivatedDidLog.toString(), ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(1))); // MUT
+                    .deactivateDidLog(didLogToDeactivate.toString(), ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(1))); // MUT
         });
 
-        assertDeactivatedDidLogEntry(nextLogEntry.get());
+        var didLogDeactivated = new StringBuilder(initialDidLogEntry).append(System.lineSeparator()).append(nextLogEntry.get()).toString();
+        assertDeactivatedDidLogEntry(nextLogEntry.get(), didLogDeactivated);
 
         // Try updating the DID log
         var updaterExc = assertThrowsExactly(DidLogUpdaterStrategyException.class, () -> {
             WebVerifiableHistoryUpdater.builder()
                     .cryptographicSuite(TEST_CRYPTO_SUITE)
                     .build()
-                    .updateDidLog(new StringBuilder(initialDidLogEntry).append(System.lineSeparator()).append(nextLogEntry.get()).toString(),
+                    .updateDidLog(didLogDeactivated,
                             // The versionTime for each log entry MUST be greater than the previous entry’s time.
                             // The versionTime of the last entry MUST be earlier than the current time.
                             ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(2));
         });
-        assertEquals("DID already deactivated", updaterExc.getMessage());
+        assertTrue(updaterExc.getMessage().contains("Document has been deactivated"));
     }
 
     @Test
@@ -155,7 +162,7 @@ class WebVerifiableHistoryDeactivatorTest extends AbstractUtilTestBase {
         var initialDidLogEntry = buildInitialWebVerifiableHistoryDidLogEntry(TEST_CRYPTO_SUITE);
 
         // CAUTION The line separator is appended intentionally - to be able to reproduce the case with multiple line separators
-        StringBuilder deactivatedDidLog = new StringBuilder(initialDidLogEntry).append(System.lineSeparator());
+        StringBuilder didLogToDeactivate = new StringBuilder(initialDidLogEntry).append(System.lineSeparator());
 
         AtomicReference<String> nextLogEntry = new AtomicReference<>();
         assertDoesNotThrow(() -> {
@@ -164,12 +171,12 @@ class WebVerifiableHistoryDeactivatorTest extends AbstractUtilTestBase {
                     .build()
                     // The versionTime for each log entry MUST be greater than the previous entry’s time.
                     // The versionTime of the last entry MUST be earlier than the current time.
-                    .deactivateDidLog(deactivatedDidLog.toString(), ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(1))); // MUT
+                    .deactivateDidLog(didLogToDeactivate.toString(), ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(1))); // MUT
         });
 
-        assertDeactivatedDidLogEntry(nextLogEntry.get());
+        var didLogDeactivated = didLogToDeactivate.append(nextLogEntry.get()).append(System.lineSeparator()).toString();
 
-        deactivatedDidLog.append(nextLogEntry.get()).append(System.lineSeparator());
+        assertDeactivatedDidLogEntry(nextLogEntry.get(), didLogDeactivated);
 
         // trying to deactivate it again should fail
         var exc = assertThrowsExactly(DidLogDeactivatorStrategyException.class, () -> {
@@ -178,9 +185,9 @@ class WebVerifiableHistoryDeactivatorTest extends AbstractUtilTestBase {
                     .build()
                     // The versionTime for each log entry MUST be greater than the previous entry’s time.
                     // The versionTime of the last entry MUST be earlier than the current time.
-                    .deactivateDidLog(deactivatedDidLog.toString(), ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(2))); // MUT
+                    .deactivateDidLog(didLogDeactivated, ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(2))); // MUT
         });
-        assertEquals("DID already deactivated", exc.getMessage());
+        assertTrue(exc.getMessage().contains("Document has been deactivated."));
     }
 
     @DisplayName("Deactivating DID log without cryptographic suite throws IncompleteDidLogEntryBuilderException")

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryUpdaterTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryUpdaterTest.java
@@ -191,8 +191,7 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
                     .authentications(TEST_AUTHENTICATIONS)
                     // 2nd updateKey supplied explicitly (from file)
                     .updateKeysDidMethodParameter(Set.of(UpdateKeysDidMethodParameter.of(
-                            //new File(TEST_DATA_PATH_PREFIX + "public.pem"), // matches TEST_VERIFICATION_METHOD_KEY_PROVIDER_JKS
-                            Path.of(TEST_DATA_PATH_PREFIX + "public01.pem") // matches TEST_VERIFICATION_METHOD_KEY_PROVIDER_ANOTHER
+                            TEST_CRYPTO_SUITE_JKS.getVerificationKeyMultibase()
                     )))
                     .build()
                     // The versionTime for each log entry MUST be greater than the previous entry’s time.
@@ -382,6 +381,7 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
         });
     }
 
+    /* TODO@MP rewrite test to switch keys
     @DisplayName("Multiple update of DID log using various existing (pre-rotation) keys")
     @Test
     void testMultipleUpdateDidLogWithKeyPrerotation() {
@@ -433,6 +433,7 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
             new Did(WebVerifiableHistoryDidLogMetaPeeker.peek(finalUpdatedDidLog).getDidDoc().getId()).resolveAll(finalUpdatedDidLog); // the ultimate test
         });
     }
+     */
 
     @DisplayName("Updating DID log without cryptographic suite (or verification material) throws IncompleteDidLogEntryBuilderException")
     @Test

--- a/src/test/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryUpdaterTest.java
+++ b/src/test/java/ch/admin/bj/swiyu/didtoolbox/webvh/WebVerifiableHistoryUpdaterTest.java
@@ -25,19 +25,12 @@ import static org.junit.jupiter.api.Assertions.*;
 class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
 
     private static void assertDidLogEntry(String didLogEntry) {
-
         assertNotNull(didLogEntry);
         assertTrue(JsonParser.parseString(didLogEntry).isJsonObject());
         var jsonObject = JsonParser.parseString(didLogEntry).getAsJsonObject();
 
         assertTrue(jsonObject.get("parameters").isJsonObject());
         assertFalse(jsonObject.get("parameters").isJsonNull());
-        //assertTrue(jsonObject.get("parameters").getAsJsonObject().isEmpty());
-        //var params = jsonObject.get("parameters").getAsJsonObject();
-        //assertTrue(params.has("method"));
-        //assertTrue(params.has("scid"));
-        //assertTrue(params.has(NamedDidMethodParameters.UPDATE_KEYS));
-        //assertTrue(params.get(NamedDidMethodParameters.UPDATE_KEYS).isJsonArray());
 
         assertTrue(jsonObject.get("state").isJsonObject());
         var didDoc = jsonObject.get("state").getAsJsonObject();
@@ -83,7 +76,6 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
 
     @Test
     void testUpdateDidLogThrowsUpdateKeyMismatchDidLogUpdaterStrategyException() {
-
         var exc = assertThrowsExactly(DidLogUpdaterStrategyException.class, () -> {
 
             WebVerifiableHistoryUpdater.builder()
@@ -106,7 +98,6 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
 
     @Test
     void testUpdateDidLogThrowsDateTimeInThePastDidLogUpdaterStrategyException() {
-
         var exc = assertThrowsExactly(DidLogUpdaterStrategyException.class, () -> {
             WebVerifiableHistoryUpdater.builder()
                     .cryptographicSuite(TEST_CRYPTO_SUITE_JKS)
@@ -120,7 +111,6 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
 
     @Test
     void testUpdateDidLogWithKeyAlternationUsingExistingUpdateKey() {
-
         // Also features an updateKey matching VERIFICATION_METHOD_KEY_PROVIDER
         var initialDidLogEntry = buildInitialWebVerifiableHistoryDidLogEntry(TEST_CRYPTO_SUITE);
 
@@ -129,7 +119,6 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
         StringBuilder updatedDidLog = new StringBuilder(initialDidLogEntry).append(System.lineSeparator());
 
         try {
-
             nextLogEntry = WebVerifiableHistoryUpdater.builder()
                     //.verificationMethodKeyProvider(EXAMPLE_VERIFICATION_METHOD_KEY_PROVIDER)
                     .cryptographicSuite(TEST_CRYPTO_SUITE_JKS) // using a whole another verification key provider
@@ -165,7 +154,6 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
     @DisplayName("Updating DID log by using another (pre-rotation) key")
     @Test
     void testUpdateDidLogWithKeyPrerotationInInitialDidLogEntry() {
-
         // The initial entry features 2 pre-rotation keys, both eligible for updating the DID log
         var initialDidLogEntry = buildInitialWebVerifiableHistoryDidLogEntryWithKeyPrerotation(
                 Set.of(
@@ -205,13 +193,10 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
         // While active, the properties nextKeyHashes and updateKeys MUST be present in all log entries.
         var params = JsonParser.parseString(nextLogEntry.get()).getAsJsonObject().get("parameters").getAsJsonObject();
         assertTrue(params.has(NamedDidMethodParameters.UPDATE_KEYS));
-        //assertTrue(params.has(NamedDidMethodParameters.NEXT_KEY_HASHES));
 
         updatedDidLog.append(nextLogEntry.get()).append(System.lineSeparator());
-        //System.out.println(updatedDidLog);
 
         var finalUpdatedDidLog = updatedDidLog.toString().trim(); // trimming due to a closing line separator
-        // System.out.println(finalUpdatedDidLog); // checkpoint
         assertDoesNotThrow(() -> {
             assertEquals(2, WebVerifiableHistoryDidLogMetaPeeker.peek(finalUpdatedDidLog).getLastVersionNumber()); // there should be another entry i.e. one more
             var did = new Did(WebVerifiableHistoryDidLogMetaPeeker.peek(initialDidLogEntry).getDidDoc().getId()).resolveAll(finalUpdatedDidLog); // the ultimate test
@@ -221,7 +206,6 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
 
     @Test
     void testUpdateDidLogWithKeyPrerotationThrowsUpdateKeyMismatchDidLogUpdaterStrategyException() {
-
         // The initial entry features pre-rotation key(s), eligible for the DID log update
         var initialDidLogEntry = buildInitialWebVerifiableHistoryDidLogEntryWithKeyPrerotation(
                 Set.of(
@@ -248,7 +232,6 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
 
     @Test
     void testUpdateDidLogWithKeyPrerotationThrowsIllegalUpdateKeyDidLogUpdaterStrategyException() {
-
         // The initial entry features pre-rotation key(s), eligible for the DID log update
         var initialDidLogEntry = buildInitialWebVerifiableHistoryDidLogEntryWithKeyPrerotation(
                 Set.of(
@@ -271,13 +254,12 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
                     // The versionTime of the last entry MUST be earlier than the current time.
                     .updateDidLog(updatedDidLog.toString(), ZonedDateTime.parse(ISO_DATE_TIME).plusSeconds(1)); // MUT
         });
-        assertEquals("Illegal updateKey detected", exc.getMessage());
+        assertEquals("Illegal update key detected, not all verification keys are allowed to rotate to.", exc.getMessage());
     }
 
     @DisplayName("Updating DID log by alternating between various existing (alternate) keys")
     @Test
     void testUpdateDidLogWithKeyAlternation() {
-
         // Also features an updateKey matching TEST_VERIFICATION_METHOD_KEY_PROVIDER_JKS
         AtomicReference<String> initialDidLogEntry = new AtomicReference<>();
         assertDoesNotThrow(() -> {
@@ -332,7 +314,6 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
     @DisplayName("Multiple update of DID log using various existing (alternate) keys")
     @Test
     void testMultipleUpdateDidLogWithKeyAlternation() {
-
         var verificationMethodKeyProvider = TEST_CRYPTO_SUITES[0]; // irrelevant
         // Also features an updateKey matching TEST_VERIFICATION_METHOD_KEY_PROVIDER_JKS
         var initialDidLogEntry = buildInitialWebVerifiableHistoryDidLogEntry(verificationMethodKeyProvider);
@@ -343,7 +324,6 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
                 TEST_CRYPTO_SUITE_JKS,
         };
 
-        //String nextLogEntry;
         AtomicReference<StringBuilder> updatedDidLog = new AtomicReference<>();
         int totalEntriesCount = 5;
         assertDoesNotThrow(() -> {
@@ -381,11 +361,9 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
         });
     }
 
-    /* TODO@MP rewrite test to switch keys
     @DisplayName("Multiple update of DID log using various existing (pre-rotation) keys")
     @Test
     void testMultipleUpdateDidLogWithKeyPrerotation() {
-
         var initialDidLogEntry = buildInitialWebVerifiableHistoryDidLogEntryWithKeyPrerotation(Set.of(
                 TEST_KEY_FILES[0] // the (single) pre-rotation key to be used when building the next DID log entry
         ));
@@ -408,6 +386,9 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
                         //         "invalid DID method parameter: invalid DID parameter: Invalid update key found. UpdateKey may only be set during key pre-rotation."
                         // Using alternative and more potent method to supply pre-rotation keys.
                         // BTW Adding the same key (via another method) has no effect as eventually distinct key values are taken.
+                        .updateKeysDidMethodParameter(Set.of(
+                                UpdateKeysDidMethodParameter.of(TEST_KEY_FILES[i - 2].toPath())
+                        ))
                         .nextKeyHashesDidMethodParameter(Set.of(
                                 NextKeyHashesDidMethodParameter.of(
                                         TEST_KEY_FILES[i - 1].toPath() // get a whole another (single) pre-rotation key to be used when building the next DID log entry
@@ -433,12 +414,10 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
             new Did(WebVerifiableHistoryDidLogMetaPeeker.peek(finalUpdatedDidLog).getDidDoc().getId()).resolveAll(finalUpdatedDidLog); // the ultimate test
         });
     }
-     */
 
     @DisplayName("Updating DID log without cryptographic suite (or verification material) throws IncompleteDidLogEntryBuilderException")
     @Test
-    public void testUpdateDidLogWithoutCryptographicSuiteThrowsIncompleteDidLogEntryBuilderException() {
-
+    void testUpdateDidLogWithoutCryptographicSuiteThrowsIncompleteDidLogEntryBuilderException() {
         var initialDidLogEntry = buildInitialWebVerifiableHistoryDidLogEntry(TEST_CRYPTO_SUITE);
 
         var exc = assertThrowsExactly(IncompleteDidLogEntryBuilderException.class, () -> {
@@ -459,5 +438,23 @@ class WebVerifiableHistoryUpdaterTest extends AbstractUtilTestBase {
                     .updateDidLog(initialDidLogEntry); // MUT
         });
         assertTrue(exc.getMessage().contains("No update will take place as no verification material is supplied whatsoever"));
+    }
+
+    @Test
+    void testUpdateDidLogWithSameKeyInUpdateAndNextHashThrowsDidLogUpdaterStrategyException() {
+        var initialDidLog = buildWebVhDidLog(TEST_CRYPTO_SUITE);
+
+        var e = assertThrowsExactly(DidLogUpdaterStrategyException.class, () -> {
+            WebVerifiableHistoryUpdater.builder()
+                    .cryptographicSuite(TEST_CRYPTO_SUITE)
+                    .authentications(TEST_AUTHENTICATIONS)
+                    .assertionMethods(TEST_ASSERTION_METHODS)
+                    .nextKeyHashesDidMethodParameter(Set.of(
+                            NextKeyHashesDidMethodParameter.of(Path.of("src/test/data/public01.pem")),
+                            NextKeyHashesDidMethodParameter.of(Path.of("src/test/data/public.pem"))
+                    ))
+                    .build().updateDidLog(initialDidLog);
+        });
+        assertEquals("Rotating to currently used update key is not allowed.", e.getMessage());
     }
 }


### PR DESCRIPTION
Added check that keys provided for key rotation are different from the current update keys.

Changed the verifyingkeys, making it optional.
Furthermore, it now reflects the updateKeys parameter, meaning it can be used to change them without key prerotation.